### PR TITLE
Assorted rules

### DIFF
--- a/rules/c/security/sizeof-this-c.yml
+++ b/rules/c/security/sizeof-this-c.yml
@@ -1,0 +1,13 @@
+id: sizeof-this-c
+language: c
+severity: warning
+message: >-
+  Do not use `sizeof(this)` to get the number of bytes of the object in
+  memory. It returns the size of the pointer, not the size of the object.
+note: >-
+  [CWE-467]: Use of sizeof() on a Pointer Type
+  [REFERENCES]
+      - https://wiki.sei.cmu.edu/confluence/display/c/ARR01-C.+Do+not+apply+the+sizeof+operator+to+a+pointer+when+taking+the+size+of+an+array
+rule:
+  any:
+    - pattern: "sizeof(this)"

--- a/rules/html/security/plaintext-http-link-html.yml
+++ b/rules/html/security/plaintext-http-link-html.yml
@@ -1,0 +1,15 @@
+id: plaintext-http-link-html
+language: html
+severity: info
+message: >-
+  This link points to a plaintext HTTP URL. Prefer an encrypted HTTPS URL
+       if possible.
+note: >-
+  [CWE-319] Authentication Bypass by Primary Weakness
+  [REFERENCES]
+      -  https://cwe.mitre.org/data/definitions/319.html
+rule:
+  pattern: <a $$$ href=$URL>$C</a>
+constraints:
+  URL:
+    regex: ^['"`]?([Hh][Tt][Tt][Pp]://)

--- a/rules/java/security/cbc-padding-oracle-java.yml
+++ b/rules/java/security/cbc-padding-oracle-java.yml
@@ -1,0 +1,17 @@
+id: cbc-padding-oracle-java
+severity: warning
+language: java
+message: >-
+  Using CBC with PKCS5Padding is susceptible to padding oracle attacks. A
+      malicious actor could discern the difference between plaintext with valid
+      or invalid padding. Further, CBC mode does not include any integrity
+      checks. Use 'AES/GCM/NoPadding' instead.
+note: >-
+  [CWE-327] Use of a Broken or Risky Cryptographic Algorithm.
+  [REFERENCES]
+      - https://capec.mitre.org/data/definitions/463.html
+rule:
+  pattern: Cipher.getInstance($MODE)
+constraints:
+  MODE:
+    regex: ".*/CBC/PKCS5Padding"

--- a/rules/java/security/desede-is-deprecated-java.yml
+++ b/rules/java/security/desede-is-deprecated-java.yml
@@ -1,0 +1,16 @@
+id: desede-is-deprecated-java
+language: java
+severity: warning
+message: >-
+  Triple DES (3DES or DESede) is considered deprecated. AES is the recommended cipher. Upgrade to use AES.
+note: >-
+  [CWE-326]: Inadequate Encryption Strength
+  [OWASP A03:2017]: Sensitive Data Exposure
+  [OWASP A02:2021]: Cryptographic Failures
+  [REFERENCES]
+      - https://find-sec-bugs.github.io/bugs.htm#TDES_USAGE
+      - https://csrc.nist.gov/News/2017/Update-to-Current-Use-and-Deprecation-of-TDEA
+rule:
+  any:
+    - pattern: $CIPHER.getInstance("=~/DESede.*/")
+    - pattern: $CRYPTO.KeyGenerator.getInstance("DES")

--- a/rules/java/security/rsa-no-padding-java.yml
+++ b/rules/java/security/rsa-no-padding-java.yml
@@ -1,0 +1,14 @@
+id: rsa-no-padding-java
+severity: warning
+language: java
+message: >-
+  Using RSA without OAEP mode weakens the encryption.
+note: >-
+  [CWE-326] Inadequate Encryption Strength
+  [REFERENCES]
+      - https://rdist.root.org/2009/10/06/why-rsa-encryption-padding-is-critical/
+rule:
+  pattern: $YST.getInstance($MODE)
+constraints:
+  MODE:
+    regex: "RSA/[Nn][Oo][Nn][Ee]/NoPadding"

--- a/rules/kotlin/security/desede-is-deprecated-kotlin.yml
+++ b/rules/kotlin/security/desede-is-deprecated-kotlin.yml
@@ -1,0 +1,16 @@
+id: desede-is-deprecated-kotlin
+language: kotlin
+severity: warning
+message: >-
+  Triple DES (3DES or DESede) is considered deprecated. AES is the recommended cipher. Upgrade to use AES.
+note: >-
+  [CWE-326]: Inadequate Encryption Strength
+  [OWASP A03:2017]: Sensitive Data Exposure
+  [OWASP A02:2021]: Cryptographic Failures
+  [REFERENCES]
+      - https://find-sec-bugs.github.io/bugs.htm#TDES_USAGE
+      - https://csrc.nist.gov/News/2017/Update-to-Current-Use-and-Deprecation-of-TDEA
+rule:
+  any:
+    - pattern: $CIPHER.getInstance("=~/DESede.*/")
+    - pattern: $CRYPTO.KeyGenerator.getInstance("DES")

--- a/rules/scala/security/rsa-padding-set-scala.yml
+++ b/rules/scala/security/rsa-padding-set-scala.yml
@@ -1,0 +1,15 @@
+id: rsa-padding-set-scala
+language: scala
+severity: warning
+message: >-
+  Usage of RSA without OAEP (Optimal Asymmetric Encryption Padding) may.
+note: >-
+  [CWE-780] Use of RSA Algorithm without OAEP
+  [REFERENCES]
+      - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+rule:
+  any:
+    - pattern: $CIPHER.getInstance($MODE)
+constraints:
+  MODE:
+    regex: ".*RSA/.*/NoPadding.*"

--- a/rules/swift/security/insecure-biometrics-swift.yml
+++ b/rules/swift/security/insecure-biometrics-swift.yml
@@ -1,0 +1,18 @@
+id: insecure-biometrics-swift
+language: swift
+severity: info
+message: >-
+  The application was observed to leverage biometrics via Local
+      Authentication, which returns a simple boolean result for authentication.
+      This design is subject to bypass with runtime tampering tools such as
+      Frida, Substrate, and others. Although this is limited to rooted
+      (jailbroken) devices, consider implementing biometric authentication the
+      reliable way - via Keychain Services.
+note: >-
+  [CWE-305] Authentication Bypass by Primary Weakness
+  [REFERENCES]
+      - https://mobile-security.gitbook.io/mobile-security-testing-guide/ios-testing-guide/0x06f-testing-local-authentication
+      - https://shirazkhan030.medium.com/biometric-authentication-in-ios-6c53c54f17df
+rule:
+  pattern: |
+    $X.evaluatePolicy

--- a/tests/__snapshots__/cbc-padding-oracle-java-snapshot.yml
+++ b/tests/__snapshots__/cbc-padding-oracle-java-snapshot.yml
@@ -1,0 +1,17 @@
+id: cbc-padding-oracle-java
+snapshots:
+  ? |-
+    Cipher doNothingCihper = new NullCipher();
+    new javax.crypto.NullCipher();
+  : labels:
+    - source: new NullCipher()
+      style: primary
+      start: 25
+      end: 41
+  ? |
+    Cipher.getInstance("AES/CBC/PKCS5Padding");
+  : labels:
+    - source: Cipher.getInstance("AES/CBC/PKCS5Padding")
+      style: primary
+      start: 0
+      end: 42

--- a/tests/__snapshots__/desede-is-deprecated-java-snapshot.yml
+++ b/tests/__snapshots__/desede-is-deprecated-java-snapshot.yml
@@ -1,0 +1,10 @@
+id: desede-is-deprecated-java
+snapshots:
+  ? |
+    Cipher.getInstance("DESede/ECB/PKCS5Padding");
+    javax.crypto.KeyGenerator.getInstance("DES")
+  : labels:
+    - source: javax.crypto.KeyGenerator.getInstance("DES")
+      style: primary
+      start: 47
+      end: 91

--- a/tests/__snapshots__/desede-is-deprecated-kotlin-snapshot.yml
+++ b/tests/__snapshots__/desede-is-deprecated-kotlin-snapshot.yml
@@ -4,7 +4,7 @@ snapshots:
     Cipher.getInstance("DESede/ECB/PKCS5Padding");
     javax.crypto.KeyGenerator.getInstance("DES")
   : labels:
-      - source: javax.crypto.KeyGenerator.getInstance("DES")
-        style: primary
-        start: 47
-        end: 91
+    - source: javax.crypto.KeyGenerator.getInstance("DES")
+      style: primary
+      start: 47
+      end: 91

--- a/tests/__snapshots__/desede-is-deprecated-kotlin-snapshot.yml
+++ b/tests/__snapshots__/desede-is-deprecated-kotlin-snapshot.yml
@@ -1,0 +1,10 @@
+id: desede-is-deprecated-kotlin
+snapshots:
+  ? |
+    Cipher.getInstance("DESede/ECB/PKCS5Padding");
+    javax.crypto.KeyGenerator.getInstance("DES")
+  : labels:
+      - source: javax.crypto.KeyGenerator.getInstance("DES")
+        style: primary
+        start: 47
+        end: 91

--- a/tests/__snapshots__/insecure-biometrics-swift-snapshot.yml
+++ b/tests/__snapshots__/insecure-biometrics-swift-snapshot.yml
@@ -1,16 +1,9 @@
 id: insecure-biometrics-swift
 snapshots:
   ? |
-    context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Authenticate to the application
-  : labels:
-      - source: context.evaluatePolicy
-        style: primary
-        start: 0
-        end: 22
-  ? |
     context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Authenticate to the application"
   : labels:
-      - source: context.evaluatePolicy
-        style: primary
-        start: 0
-        end: 22
+    - source: context.evaluatePolicy
+      style: primary
+      start: 0
+      end: 22

--- a/tests/__snapshots__/insecure-biometrics-swift-snapshot.yml
+++ b/tests/__snapshots__/insecure-biometrics-swift-snapshot.yml
@@ -1,0 +1,16 @@
+id: insecure-biometrics-swift
+snapshots:
+  ? |
+    context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Authenticate to the application
+  : labels:
+      - source: context.evaluatePolicy
+        style: primary
+        start: 0
+        end: 22
+  ? |
+    context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Authenticate to the application"
+  : labels:
+      - source: context.evaluatePolicy
+        style: primary
+        start: 0
+        end: 22

--- a/tests/__snapshots__/plaintext-http-link-html-snapshot.yml
+++ b/tests/__snapshots__/plaintext-http-link-html-snapshot.yml
@@ -1,0 +1,15 @@
+id: plaintext-http-link-html
+snapshots:
+  ? |
+    <a href="http://semgrep.dev">Semgrep</a>
+    <a href='http://semgrep.dev'>Semgrep</a>
+    <a href=http://semgrep.dev>Semgrep</a>
+    <a class="foo" href="http://semgrep.dev">Semgrep</a>
+    <a class='foo' href='http://semgrep.dev'>Semgrep</a>
+    <a class=foo href=http://semgrep.dev>Semgrep</a>
+    <a href="HTTP://SEMGREP.DEV">Semgrep</a>
+  : labels:
+    - source: <a href="http://semgrep.dev">Semgrep</a>
+      style: primary
+      start: 0
+      end: 40

--- a/tests/__snapshots__/rsa-no-padding-java-snapshot.yml
+++ b/tests/__snapshots__/rsa-no-padding-java-snapshot.yml
@@ -2,7 +2,15 @@ id: rsa-no-padding-java
 snapshots:
   Cipher.getInstance("RSA/ECB/NoPadding"):
     labels:
-      - source: Cipher.getInstance("RSA/ECB/NoPadding")
-        style: primary
-        start: 0
-        end: 39
+    - source: Cipher.getInstance("RSA/ECB/NoPadding")
+      style: primary
+      start: 0
+      end: 39
+  ? |
+    Cipher.getInstance("RSA/None/NoPadding");
+    Cipher.getInstance("RSA/NONE/NoPadding");
+  : labels:
+    - source: Cipher.getInstance("RSA/None/NoPadding")
+      style: primary
+      start: 0
+      end: 40

--- a/tests/__snapshots__/rsa-no-padding-java-snapshot.yml
+++ b/tests/__snapshots__/rsa-no-padding-java-snapshot.yml
@@ -1,0 +1,9 @@
+id: rsa-no-padding-java
+snapshots: {}
+snapshots:
+  Cipher.getInstance("RSA/ECB/NoPadding"):
+    labels:
+    - source: Cipher.getInstance("RSA/ECB/NoPadding")
+      style: primary
+      start: 0
+      end: 39

--- a/tests/__snapshots__/rsa-no-padding-java-snapshot.yml
+++ b/tests/__snapshots__/rsa-no-padding-java-snapshot.yml
@@ -1,9 +1,8 @@
 id: rsa-no-padding-java
-snapshots: {}
 snapshots:
   Cipher.getInstance("RSA/ECB/NoPadding"):
     labels:
-    - source: Cipher.getInstance("RSA/ECB/NoPadding")
-      style: primary
-      start: 0
-      end: 39
+      - source: Cipher.getInstance("RSA/ECB/NoPadding")
+        style: primary
+        start: 0
+        end: 39

--- a/tests/__snapshots__/rsa-padding-set-scala-snapshot.yml
+++ b/tests/__snapshots__/rsa-padding-set-scala-snapshot.yml
@@ -1,2 +1,9 @@
 id: rsa-padding-set-scala
-snapshots: {}
+snapshots:
+  ? |
+    Cipher.getInstance("RSA/ECB/NoPadding")
+  : labels:
+    - source: Cipher.getInstance("RSA/ECB/NoPadding")
+      style: primary
+      start: 0
+      end: 39

--- a/tests/__snapshots__/rsa-padding-set-scala-snapshot.yml
+++ b/tests/__snapshots__/rsa-padding-set-scala-snapshot.yml
@@ -1,0 +1,2 @@
+id: rsa-padding-set-scala
+snapshots: {}

--- a/tests/__snapshots__/sizeof-this-c-snapshot.yml
+++ b/tests/__snapshots__/sizeof-this-c-snapshot.yml
@@ -1,0 +1,9 @@
+id: sizeof-this-c
+snapshots:
+  ? |
+    return sizeof(this);
+  : labels:
+    - source: sizeof(this)
+      style: primary
+      start: 7
+      end: 19

--- a/tests/c/sizeof-this-c-test.yml
+++ b/tests/c/sizeof-this-c-test.yml
@@ -1,0 +1,7 @@
+id: sizeof-this-c
+valid:
+  - |
+    return sizeof(*this);
+invalid:
+  - |
+    return sizeof(this);

--- a/tests/html/plaintext-http-link-html-test.yml
+++ b/tests/html/plaintext-http-link-html-test.yml
@@ -1,0 +1,15 @@
+id: plaintext-http-link-html
+valid:
+  - |
+    <a href="https://semgrep.dev">Semgrep</a>
+    <a href="https://semgrep.dev/http://">Semgrep</a>
+    <a href="javascript:alert(1)">Semgrep</a>
+invalid:
+  - |
+    <a href="http://semgrep.dev">Semgrep</a>
+    <a href='http://semgrep.dev'>Semgrep</a>
+    <a href=http://semgrep.dev>Semgrep</a>
+    <a class="foo" href="http://semgrep.dev">Semgrep</a>
+    <a class='foo' href='http://semgrep.dev'>Semgrep</a>
+    <a class=foo href=http://semgrep.dev>Semgrep</a>
+    <a href="HTTP://SEMGREP.DEV">Semgrep</a>

--- a/tests/java/cbc-padding-oracle-test.yml
+++ b/tests/java/cbc-padding-oracle-test.yml
@@ -1,11 +1,7 @@
-id: cbc-padding-oracle
+id: cbc-padding-oracle-java
 valid:
   - |
-    Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
-    c.init(Cipher.ENCRYPT_MODE, k, iv);
-    byte[] cipherText = c.doFinal(plainText);
+    Cipher.getInstance("AES/GCM/NoPadding");
 invalid:
   - |
-    Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-    IvParameterSpec iv = new IvParameterSpec(new byte[16]);
-    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(new byte[16], "AES"), iv);
+    Cipher.getInstance("AES/CBC/PKCS5Padding");

--- a/tests/java/desede-is-deprecated-java-test.yml
+++ b/tests/java/desede-is-deprecated-java-test.yml
@@ -1,0 +1,8 @@
+id: desede-is-deprecated-java
+valid:
+  - |
+    Cipher.getInstance("AES/GCM/NoPadding");
+invalid:
+  - |
+    Cipher.getInstance("DESede/ECB/PKCS5Padding");
+    javax.crypto.KeyGenerator.getInstance("DES")

--- a/tests/java/rsa-no-padding-java-test.yml
+++ b/tests/java/rsa-no-padding-java-test.yml
@@ -1,0 +1,8 @@
+id: rsa-no-padding-java
+valid:
+  - |
+    Cipher.getInstance("RSA/ECB/OAEPWithMD5AndMGF1Padding");
+invalid:
+  - |
+    Cipher.getInstance("RSA/None/NoPadding");
+    Cipher.getInstance("RSA/NONE/NoPadding");

--- a/tests/kotlin/desede-is-deprecated-kotlin-test.yml
+++ b/tests/kotlin/desede-is-deprecated-kotlin-test.yml
@@ -1,0 +1,8 @@
+id: desede-is-deprecated-kotlin
+valid:
+  - |
+    Cipher.getInstance("AES/GCM/NoPadding");
+invalid:
+  - |
+    Cipher.getInstance("DESede/ECB/PKCS5Padding");
+    javax.crypto.KeyGenerator.getInstance("DES")

--- a/tests/scala/rsa-padding-set-scala-test.yml
+++ b/tests/scala/rsa-padding-set-scala-test.yml
@@ -1,0 +1,9 @@
+id: rsa-padding-set-scala
+valid:
+  - |
+    Cipher.getInstance("AES/CBC/PKCS5Padding");
+    Cipher.getInstance("DES/ECB/PKCS5Padding");
+    Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+invalid:
+  - |
+    Cipher.getInstance("RSA/ECB/NoPadding")

--- a/tests/swift/insecure-biometrics-swift-test.yml
+++ b/tests/swift/insecure-biometrics-swift-test.yml
@@ -1,0 +1,7 @@
+id: insecure-biometrics-swift
+valid:
+  - |
+    context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
+invalid:
+  - |
+    context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Authenticate to the application"


### PR DESCRIPTION
Rule id - insecure-biometrics-swift
Language - Swift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a security rule for Java applications to alert developers about insecure RSA encryption practices without OAEP.
	- Established a security rule for Kotlin applications to mark Triple DES (3DES) as deprecated, encouraging a transition to AES.
	- Added snapshot testing for RSA encryption configurations to validate expected behaviors.
	- Created comprehensive test cases for evaluating valid and invalid cryptographic algorithms in Java.
	- Defined a security rule for C programming to warn against improper use of the `sizeof` operator with the `this` pointer.
	- Introduced a security rule for HTML to identify plaintext HTTP links, promoting the use of HTTPS.

- **Documentation**
	- Provided documentation on RSA encryption practices to inform developers about potential vulnerabilities related to inadequate encryption strength.
	- Included guidance on the deprecation of 3DES and best practices for modern encryption standards.
	- Added references to the misuse of the `sizeof` operator in C, emphasizing correct application in memory management.
	- Documented the risks associated with plaintext HTTP links and the importance of using secure URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->