### PR TITLE
One java and one rust rule

### DIFF
--- a/rules/java/security/use-of-default-aes-java.yml
+++ b/rules/java/security/use-of-default-aes-java.yml
@@ -1,0 +1,89 @@
+id: use-of-default-aes-java
+language: java
+severity: warning
+message: >-
+  Use of AES with no settings detected. By default, java.crypto.Cipher
+  uses ECB mode. ECB doesn't  provide message confidentiality and is not
+  semantically secure so should not be used. Instead, use a strong, secure
+  cipher: java.crypto.Cipher.getInstance(\"AES/CBC/PKCS7PADDING\"). See
+  https://owasp.org/www-community/Using_the_Java_Cryptographic_Extensions
+  for more information.
+note: >-
+  [CWE-327] Use of a Broken or Risky Cryptographic Algorithm.
+  [REFERENCES]
+      - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+      - https://googleprojectzero.blogspot.com/2022/10/rc4-is-still-considered-harmful.html
+rule:
+  any:
+    - pattern: Cipher.getInstance("AES")
+      inside:
+        stopBy: end
+        kind: class_declaration
+        follows:
+          stopBy: end
+          kind: import_declaration
+          any:
+            - pattern: import javax.*
+            - pattern: import javax
+    - pattern: crypto.Cipher.getInstance("AES")
+      inside:
+        stopBy: end
+        kind: class_declaration
+        follows:
+          stopBy: end
+          kind: import_declaration
+          any:
+            - pattern: import javax.*
+            - pattern: import javax
+    - pattern: javax.crypto.Cipher.getInstance("AES")
+      inside:
+        stopBy: end
+        kind: class_declaration
+        follows:
+          stopBy: end
+          kind: import_declaration
+          any:
+            - pattern: import javax.*
+            - pattern: import javax
+    - pattern: $D.getInstance("AES");
+      all:
+        - follows:
+            stopBy: end
+            pattern: Cipher $D = $$$
+        - inside:
+            stopBy: end
+            kind: class_declaration
+            follows:
+              stopBy: end
+              kind: import_declaration
+              any:
+                - pattern: import javax.*
+                - pattern: import javax
+    - pattern: $D.getInstance("AES");
+      all:
+        - follows:
+            stopBy: end
+            pattern: javax.crypto.Cipher $D = $$$
+        - inside:
+            stopBy: end
+            kind: class_declaration
+            follows:
+              stopBy: end
+              kind: import_declaration
+              any:
+                - pattern: import javax.*
+                - pattern: import javax
+    - pattern: $D.getInstance("AES");
+      all:
+        - follows:
+            stopBy: end
+            pattern: crypto.Cipher $D = $$$
+        - inside:
+            stopBy: end
+            kind: class_declaration
+            follows:
+              stopBy: end
+              kind: import_declaration
+              any:
+                - pattern: import javax.*
+                - pattern: import javax

--- a/rules/rust/security/ssl-verify-none-rust.yml
+++ b/rules/rust/security/ssl-verify-none-rust.yml
@@ -1,0 +1,87 @@
+id: ssl-verify-none-rust
+language: rust
+severity: warning
+message: >-
+  SSL verification disabled, this allows for MitM attacks
+note: >-
+  [CWE-295]: Improper Certificate Validation
+  [REFERENCES]
+    - https://docs.rs/openssl/latest/openssl/ssl/struct.SslContextBuilder.html#method.set_verify
+
+rule:
+  kind: call_expression
+  any:
+    - pattern: $BUILDER.set_verify(open::ssl::SSL_VERIFY_NONE)
+      inside:
+        stopBy: end
+        kind: source_file
+        has:
+          kind: use_declaration
+          any:
+            - pattern: use openssl;
+            - pattern: use openssl::ssl;
+            - pattern: use openssl::ssl::SSL_VERIFY_NONE;
+            - has:
+                stopBy: end
+                kind: use_list
+                has:
+                  stopBy: end
+                  kind: identifier
+                  pattern: SSL_VERIFY_NONE
+    - pattern: $BUILDER.set_verify(ssl::SSL_VERIFY_NONE)
+      inside:
+        stopBy: end
+        kind: source_file
+        has:
+          kind: use_declaration
+          any:
+            - pattern: use openssl::ssl;
+            - pattern: use openssl::ssl::SSL_VERIFY_NONE;
+            - has:
+                stopBy: end
+                kind: use_list
+                has:
+                  stopBy: end
+                  kind: identifier
+                  pattern: SSL_VERIFY_NONE
+    - pattern: $BUILDER.set_verify(SSL_VERIFY_NONE)
+      inside:
+        stopBy: end
+        kind: source_file
+        has:
+          kind: use_declaration
+          any:
+            - pattern: use openssl;
+            - pattern: use openssl::ssl;
+            - pattern: use openssl::ssl::SSL_VERIFY_NONE;
+            - has:
+                stopBy: end
+                kind: use_list
+                has:
+                  stopBy: end
+                  kind: identifier
+                  pattern: SSL_VERIFY_NONE
+    - pattern: $BUILDER.set_verify($ALIAS)
+      inside:
+        stopBy: end
+        kind: source_file
+        has:
+          kind: use_declaration
+          any:
+            - pattern: use openssl::ssl::SSL_VERIFY_NONE as $ALIAS;
+            - has:
+                stopBy: end
+                kind: use_list
+                has:
+                  stopBy: end
+                  kind: use_as_clause
+                  all:
+                    - has:
+                        kind: identifier
+                        field: path
+                        pattern: SSL_VERIFY_NONE
+                    - has:
+                        kind: identifier
+                        field: alias
+                        pattern: $ALIAS
+    - pattern: $BUILDER.set_verify(open::ssl::SSL_VERIFY_NONE);

--- a/tests/__snapshots__/ssl-verify-none-rust-snapshot.yml
+++ b/tests/__snapshots__/ssl-verify-none-rust-snapshot.yml
@@ -1,0 +1,94 @@
+id: ssl-verify-none-rust
+snapshots:
+  ? "use openssl::ssl::{\n  SslMethod,  \n  SslConnectorBuilder,\n  SSL_VERIFY_NONE as NoVerify\n};\nconnector.builder_mut().set_verify(NoVerify);\n"
+  : labels:
+    - source: connector.builder_mut().set_verify(NoVerify)
+      style: primary
+      start: 91
+      end: 135
+    - source: SSL_VERIFY_NONE
+      style: secondary
+      start: 60
+      end: 75
+    - source: NoVerify
+      style: secondary
+      start: 79
+      end: 87
+    - source: SSL_VERIFY_NONE as NoVerify
+      style: secondary
+      start: 60
+      end: 87
+    - source: "{\n  SslMethod,  \n  SslConnectorBuilder,\n  SSL_VERIFY_NONE as NoVerify\n}"
+      style: secondary
+      start: 18
+      end: 89
+    - source: "use openssl::ssl::{\n  SslMethod,  \n  SslConnectorBuilder,\n  SSL_VERIFY_NONE as NoVerify\n};"
+      style: secondary
+      start: 0
+      end: 90
+    - source: "use openssl::ssl::{\n  SslMethod,  \n  SslConnectorBuilder,\n  SSL_VERIFY_NONE as NoVerify\n};\nconnector.builder_mut().set_verify(NoVerify);\n"
+      style: secondary
+      start: 0
+      end: 137
+  ? |
+    use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+    connector.builder_mut().set_verify(SSL_VERIFY_NONE);
+  : labels:
+    - source: connector.builder_mut().set_verify(SSL_VERIFY_NONE)
+      style: primary
+      start: 69
+      end: 120
+    - source: SSL_VERIFY_NONE
+      style: secondary
+      start: 51
+      end: 66
+    - source: '{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE}'
+      style: secondary
+      start: 18
+      end: 67
+    - source: use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+      style: secondary
+      start: 0
+      end: 68
+    - source: |
+        use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+        connector.builder_mut().set_verify(SSL_VERIFY_NONE);
+      style: secondary
+      start: 0
+      end: 122
+  ? |
+    use openssl::ssl;
+    connector.builder_mut().set_verify(ssl::SSL_VERIFY_NONE);
+  : labels:
+    - source: connector.builder_mut().set_verify(ssl::SSL_VERIFY_NONE)
+      style: primary
+      start: 18
+      end: 74
+    - source: use openssl::ssl;
+      style: secondary
+      start: 0
+      end: 17
+    - source: |
+        use openssl::ssl;
+        connector.builder_mut().set_verify(ssl::SSL_VERIFY_NONE);
+      style: secondary
+      start: 0
+      end: 76
+  ? |
+    use openssl;
+    connector.builder_mut().set_verify(open::ssl::SSL_VERIFY_NONE);
+  : labels:
+    - source: connector.builder_mut().set_verify(open::ssl::SSL_VERIFY_NONE)
+      style: primary
+      start: 13
+      end: 75
+    - source: use openssl;
+      style: secondary
+      start: 0
+      end: 12
+    - source: |
+        use openssl;
+        connector.builder_mut().set_verify(open::ssl::SSL_VERIFY_NONE);
+      style: secondary
+      start: 0
+      end: 77

--- a/tests/__snapshots__/use-of-default-aes-java-snapshot.yml
+++ b/tests/__snapshots__/use-of-default-aes-java-snapshot.yml
@@ -1,0 +1,22 @@
+id: use-of-default-aes-java
+snapshots:
+  ? "import javax;\nimport javax.crypto;     \nimport javax.crypto.*;\nimport javax.crypto.Cipher;\nclass AES{\npublic void useofAES() {\nCipher.getInstance(\"AES\");\ncrypto.Cipher.getInstance(\"AES\");\njavax.crypto.Cipher.getInstance(\"AES\");\n}\n"
+  : labels:
+    - source: Cipher.getInstance("AES")
+      style: primary
+      start: 127
+      end: 152
+    - source: import javax;
+      style: secondary
+      start: 0
+      end: 13
+    - source: |-
+        class AES{
+        public void useofAES() {
+        Cipher.getInstance("AES");
+        crypto.Cipher.getInstance("AES");
+        javax.crypto.Cipher.getInstance("AES");
+        }
+      style: secondary
+      start: 91
+      end: 229

--- a/tests/java/use-of-default-aes-java-test.yml
+++ b/tests/java/use-of-default-aes-java-test.yml
@@ -1,0 +1,17 @@
+id: use-of-default-aes-java
+valid:
+  - |
+    crypto.KeyGenerator.getInstance("AES");
+    javax.crypto.KeyGenerator.getInstance("AES");
+invalid:
+  - |
+    import javax;
+    import javax.crypto;     
+    import javax.crypto.*;
+    import javax.crypto.Cipher;
+    class AES{
+    public void useofAES() {
+    Cipher.getInstance("AES");
+    crypto.Cipher.getInstance("AES");
+    javax.crypto.Cipher.getInstance("AES");
+    }

--- a/tests/rust/ssl-verify-none-rust-test.yml
+++ b/tests/rust/ssl-verify-none-rust-test.yml
@@ -1,0 +1,22 @@
+id: ssl-verify-none-rust
+valid:
+  - |
+    use openssl::ssl::SSL_VERIFY_NONE;
+    connector.builder_mut().set_verify(SSL_VERIFY_PEER);
+invalid:
+  - |
+    use openssl;
+    connector.builder_mut().set_verify(open::ssl::SSL_VERIFY_NONE);
+  - |
+    use openssl::ssl;
+    connector.builder_mut().set_verify(ssl::SSL_VERIFY_NONE);
+  - |
+    use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+    connector.builder_mut().set_verify(SSL_VERIFY_NONE);
+  - |
+    use openssl::ssl::{
+      SslMethod,  
+      SslConnectorBuilder,
+      SSL_VERIFY_NONE as NoVerify
+    };
+    connector.builder_mut().set_verify(NoVerify);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a rule to warn against using the AES encryption algorithm without specific settings in Java, promoting secure configurations.
	- Added a rule to identify instances of disabled SSL verification in Rust, enhancing security awareness.

- **Tests**
	- Implemented test cases for AES encryption usage in Java, validating correct and incorrect patterns.
	- Created test cases for SSL verification configurations in Rust, distinguishing valid and invalid usages. 

- **Snapshots**
	- Added snapshots for both AES usage in Java and SSL verification in Rust, showcasing different implementation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->