### PR TITLE
Two Java rules

### DIFF
--- a/rules/java/security/missing-httponly-java.yml
+++ b/rules/java/security/missing-httponly-java.yml
@@ -1,0 +1,83 @@
+id: missing-httponly-java
+language: java
+severity: warning
+message: >-
+  Detected a cookie where the `HttpOnly` flag is either missing or
+  disabled. The `HttpOnly` cookie flag instructs the browser to forbid
+  client-side JavaScript to read the cookie. If JavaScript interaction is
+  required, you can ignore this finding. However, set the `HttpOnly` flag to
+  true` in all other cases.
+note: >-
+  [CWE-1004]: Sensitive Cookie Without 'HttpOnly' Flag
+  [OWASP A05:2021]: Security Misconfiguration
+  [REFERENCES]
+      - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+utils:
+  match_without_httponly:
+    kind: argument_list
+    has:
+      kind: object_creation_expression
+    inside:
+      stopBy: end
+      kind: method_invocation
+
+  match_cc2_cookie:
+    kind: local_variable_declaration
+    precedes:
+      kind: expression_statement
+      has:
+        kind: method_invocation
+        has:
+          kind: method_invocation
+          has:
+            kind: argument_list
+            has:
+              kind: string_literal
+  match_nettycookie:
+    kind: local_variable_declaration
+    all:
+      - has:
+          stopBy: end
+          kind: variable_declarator
+          has:
+            kind: object_creation_expression
+            all:
+              - has:
+                  stopBy: end
+                  kind: argument_list
+                  has:
+                    stopBy: end
+                    kind: string_literal
+                    precedes:
+                      stopBy: end
+                      kind: string_literal
+              - not:
+                  precedes:
+                    stopBy: end
+                    kind: identifier
+                    regex: "http"
+      - not:
+          precedes:
+            stopBy: neighbor
+            kind: expression_statement
+            has:
+              stopBy: end
+              kind: method_invocation
+              has:
+                stopBy: end
+                kind: argument_list
+  match_cookie_last:
+    kind: argument_list
+    has:
+      kind: method_invocation
+      has:
+        kind: argument_list
+        has:
+          kind: string_literal
+
+rule:
+  any:
+    - matches: match_cc2_cookie
+    - matches: match_without_httponly
+    - matches: match_nettycookie
+    - matches: match_cookie_last

--- a/rules/java/security/missing-secure-java.yml
+++ b/rules/java/security/missing-secure-java.yml
@@ -1,0 +1,70 @@
+id: missing-secure-java
+language: java
+severity: warning
+message: >-
+  Detected a cookie where the `Secure` flag is either missing or
+  disabled. The `Secure` cookie flag instructs the browser to forbid sending
+  the cookie over an insecure HTTP request. Set the `Secure` flag to `true`
+  so the cookie will only be sent over HTTPS.
+note: >-
+  [CWE-614]: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
+  [OWASP A05:2021]: Security Misconfiguration
+  [REFERENCES]
+      - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+utils:
+  match_without_httponly:
+    kind: argument_list
+    has:
+      kind: object_creation_expression
+    inside:
+      stopBy: end
+      kind: method_invocation
+
+  match_cookie_last:
+    kind: argument_list
+    has:
+      kind: method_invocation
+      has:
+        kind: argument_list
+        has:
+          kind: string_literal
+
+  match_instance:
+    kind: local_variable_declaration
+    has:
+      stopBy: end
+      kind: identifier
+      follows:
+        stopBy: end
+        kind: variable_declarator
+
+  match_identifier_with_simplecookie:
+    kind: identifier
+    inside:
+      stopBy: end
+      kind: local_variable_declaration
+      all:
+        - has:
+            stopBy: end
+            kind: type_identifier
+            regex: "^SimpleCookie$|^Cookie$"
+        - has:
+            stopBy: neighbor
+            kind: variable_declarator
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+              - has:
+                  stopBy: neighbor
+                  kind: object_creation_expression
+        - not:
+            precedes:
+              stopBy: neighbor
+              kind: expression_statement
+rule:
+  any:
+    - matches: match_instance
+    - matches: match_without_httponly
+    - matches: match_cookie_last
+    - matches: match_identifier_with_simplecookie

--- a/tests/__snapshots__/missing-httponly-java-snapshot.yml
+++ b/tests/__snapshots__/missing-httponly-java-snapshot.yml
@@ -1,0 +1,33 @@
+id: missing-httponly-java
+snapshots:
+  ? |
+    SimpleCookie s = new SimpleCookie("foo", "bar");
+    ( new NettyCookie( "foo", "bar" ) )
+    Cookie cc2 = Cookie.of("zzz", "ddd");
+    Cookie z = new NettyCookie("foo", "bar");
+    (Cookie.of("zzz", "ddd"))
+  : labels:
+    - source: SimpleCookie s = new SimpleCookie("foo", "bar");
+      style: primary
+      start: 0
+      end: 48
+    - source: '"foo"'
+      style: secondary
+      start: 34
+      end: 39
+    - source: '"foo"'
+      style: secondary
+      start: 34
+      end: 39
+    - source: ("foo", "bar")
+      style: secondary
+      start: 33
+      end: 47
+    - source: new SimpleCookie("foo", "bar")
+      style: secondary
+      start: 17
+      end: 47
+    - source: s = new SimpleCookie("foo", "bar")
+      style: secondary
+      start: 13
+      end: 47

--- a/tests/__snapshots__/missing-secure-java-snapshot.yml
+++ b/tests/__snapshots__/missing-secure-java-snapshot.yml
@@ -1,0 +1,32 @@
+id: missing-secure-java
+snapshots:
+  ? |
+    SimpleCookie s = new SimpleCookie("foo", "bar");
+    .orElse( new NettyCookie( "foo", "bar" ) );
+    Cookie z = new NettyCookie("foo", "bar");
+    return HttpResponse.ok().cookie(Cookie.of("zzz", "ddd"));
+  : labels:
+    - source: s
+      style: primary
+      start: 13
+      end: 14
+    - source: SimpleCookie
+      style: secondary
+      start: 0
+      end: 12
+    - source: s
+      style: secondary
+      start: 13
+      end: 14
+    - source: new SimpleCookie("foo", "bar")
+      style: secondary
+      start: 17
+      end: 47
+    - source: s = new SimpleCookie("foo", "bar")
+      style: secondary
+      start: 13
+      end: 47
+    - source: SimpleCookie s = new SimpleCookie("foo", "bar");
+      style: secondary
+      start: 0
+      end: 48

--- a/tests/java/missing-httponly-java-test.yml
+++ b/tests/java/missing-httponly-java-test.yml
@@ -1,0 +1,18 @@
+id: missing-httponly-java
+valid:
+  - |
+    Cookie c1 = getCookieSomewhere();
+    return HttpResponse.ok().cookie(Cookie.of("foo", "bar").httpOnly(true));
+    Cookie cookie = request.getCookies().findCookie( "foobar" )
+    Cookie ccc = Cookie.of("zzz", "ddd");
+    ccc.httpOnly(true).secure(true);
+    Cookie c = new NettyCookie("foo", "bar");
+    c.httpOnly(true);
+    NettyCookie r = new NettyCookie("foo", "bar").httpOnly(true);
+invalid:
+  - |
+    SimpleCookie s = new SimpleCookie("foo", "bar");
+    ( new NettyCookie( "foo", "bar" ) )
+    Cookie cc2 = Cookie.of("zzz", "ddd");
+    Cookie z = new NettyCookie("foo", "bar");
+    (Cookie.of("zzz", "ddd"))

--- a/tests/java/missing-secure-java-test.yml
+++ b/tests/java/missing-secure-java-test.yml
@@ -1,0 +1,15 @@
+id: missing-secure-java
+valid:
+  - |
+    Cookie c1 = getCookieSomewhere();
+    return HttpResponse.ok().cookie(Cookie.of("foo", "bar").secure(true));
+    Cookie cookie = request.getCookies().findCookie( "foobar" )
+    Cookie c = new NettyCookie("foo", "bar");
+    c.secure(true);
+    NettyCookie r = new NettyCookie("foo", "bar").secure(true);
+invalid:
+  - |
+    SimpleCookie s = new SimpleCookie("foo", "bar");
+    .orElse( new NettyCookie( "foo", "bar" ) );
+    Cookie z = new NettyCookie("foo", "bar");
+    return HttpResponse.ok().cookie(Cookie.of("zzz", "ddd"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new security rules for Java applications to enhance cookie security: 
		- Detection of cookies missing the `HttpOnly` flag.
		- Detection of cookies missing the `Secure` flag.
- **Tests**
	- Added test cases to validate the implementation of `HttpOnly` and `Secure` cookies.
	- New snapshot entries created for both rules to demonstrate cookie handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->