### PR TITLE
Two Go rules 10Oct2024

### DIFF
--- a/rules/go/security/missing-ssl-minversion-go.yml
+++ b/rules/go/security/missing-ssl-minversion-go.yml
@@ -1,0 +1,31 @@
+id: missing-ssl-minversion-go
+language: go
+severity: warning
+message: >-
+  MinVersion` is missing from this TLS configuration.  By default, TLS
+  1.2 is currently used as the minimum when acting as a client, and TLS 1.0
+  when acting as a server. General purpose web applications should default
+  to TLS 1.3 with all other protocols disabled.  Only where it is known that
+  a web server must support legacy clients with unsupported an insecure
+  browsers (such as Internet Explorer 10), it may be necessary to enable TLS
+  1.0 to provide support. Add `MinVersion: tls.VersionTLS13' to the TLS
+  configuration to bump the minimum version to TLS 1.3.
+note: >-
+  [CWE-327]: Use of a Broken or Risky Cryptographic Algorithm
+  [OWASP A03:2017]: Sensitive Data Exposure
+  [OWASP A02:2021]: Cryptographic Failures
+  [REFERENCES]
+       https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+utils:
+  match_tls_without_minversion:
+    kind: composite_literal
+    pattern: $R
+    inside:
+      stopBy: end
+      kind: assignment_statement
+rule:
+  any:
+    - matches: match_tls_without_minversion
+constraints:
+  R:
+    regex: ^(tls.Config)

--- a/rules/go/security/ssl-v3-is-insecure-go.yml
+++ b/rules/go/security/ssl-v3-is-insecure-go.yml
@@ -1,0 +1,17 @@
+id: ssl-v3-is-insecure-go
+language: go
+severity: warning
+message: >-
+  SSLv3 is insecure because it has known vulnerabilities. Starting with
+  go1.14, SSLv3 will be removed. Instead, use 'tls.VersionTLS13'.
+note: >-
+  [CWE-327]: Use of a Broken or Risky Cryptographic Algorithm
+  [OWASP A03:2017]: Sensitive Data Exposure
+  [OWASP A02:2021]: Cryptographic Failures
+  [REFERENCES]
+       https://golang.org/doc/go1.14#crypto/tls
+       https://www.us-cert.gov/ncas/alerts/TA14-290A
+rule:
+  kind: composite_literal
+  all:
+    - pattern: "tls.Config{$$$, MinVersion: tls.VersionSSL30, $$$}"

--- a/tests/__snapshots__/missing-ssl-minversion-go-snapshot.yml
+++ b/tests/__snapshots__/missing-ssl-minversion-go-snapshot.yml
@@ -1,0 +1,13 @@
+id: missing-ssl-minversion-go
+snapshots:
+  ? |
+    server.TLS = &tls.Config{ Rand: zeroSource{}, }
+  : labels:
+    - source: 'tls.Config{ Rand: zeroSource{}, }'
+      style: primary
+      start: 14
+      end: 47
+    - source: 'server.TLS = &tls.Config{ Rand: zeroSource{}, }'
+      style: secondary
+      start: 0
+      end: 47

--- a/tests/__snapshots__/ssl-v3-is-insecure-go-snapshot.yml
+++ b/tests/__snapshots__/ssl-v3-is-insecure-go-snapshot.yml
@@ -1,0 +1,25 @@
+id: ssl-v3-is-insecure-go
+snapshots:
+  ? |
+    client := &http.Client{
+     Transport: &http.Transport{
+       // ruleid: ssl-v3-is-insecure
+       TLSClientConfig: &tls.Config{
+         KeyLogWriter:       w,
+         MinVersion:         tls.VersionSSL30,
+         Rand:               zeroSource{}, // for reproducible output; don't do this.
+         InsecureSkipVerify: true,         // test server certificate is not trusted.
+       },
+     },
+    }
+  : labels:
+    - source: |-
+        tls.Config{
+             KeyLogWriter:       w,
+             MinVersion:         tls.VersionSSL30,
+             Rand:               zeroSource{}, // for reproducible output; don't do this.
+             InsecureSkipVerify: true,         // test server certificate is not trusted.
+           }
+      style: primary
+      start: 107
+      end: 358

--- a/tests/go/missing-ssl-minversion-go-test.yml
+++ b/tests/go/missing-ssl-minversion-go-test.yml
@@ -1,0 +1,13 @@
+id: missing-ssl-minversion-go
+valid:
+  - |
+    TLSClientConfig: &tls.Config{
+    KeyLogWriter:       w,
+    MinVersion:         tls.VersionSSL30,
+    Rand:               zeroSource{}, 
+    InsecureSkipVerify: true,        
+    },
+
+invalid:
+  - |
+    server.TLS = &tls.Config{ Rand: zeroSource{}, }

--- a/tests/go/ssl-v3-is-insecure-go-test.yml
+++ b/tests/go/ssl-v3-is-insecure-go-test.yml
@@ -1,0 +1,28 @@
+id: ssl-v3-is-insecure-go
+valid:
+  - |
+    client_good := &http.Client{
+    Transport: &http.Transport{
+      TLSClientConfig: &tls.Config{
+        KeyLogWriter: w,
+        // OK
+        MinVersion:         tls.VersionTLS10,
+        Rand:               zeroSource{}, // for reproducible output; don't do this.
+        InsecureSkipVerify: true,         // test server certificate is not trusted.
+      },
+    },
+    }
+
+invalid:
+  - |
+    client := &http.Client{
+     Transport: &http.Transport{
+       // ruleid: ssl-v3-is-insecure
+       TLSClientConfig: &tls.Config{
+         KeyLogWriter:       w,
+         MinVersion:         tls.VersionSSL30,
+         Rand:               zeroSource{}, // for reproducible output; don't do this.
+         InsecureSkipVerify: true,         // test server certificate is not trusted.
+       },
+     },
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new security rules for TLS configurations in Go applications, warning against missing minimum SSL versions and the use of insecure SSLv3.
- **Tests**
	- Added test configurations to validate SSL/TLS settings, distinguishing between valid and invalid configurations based on security standards. 
	- Created snapshots to capture TLS configuration states for both missing minimum version and insecure SSLv3 scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->