### PR TITLE
Rules - One go and one java rule  - 11Oct2024

### DIFF
--- a/rules/go/security/tls-with-insecure-cipher-go.yml
+++ b/rules/go/security/tls-with-insecure-cipher-go.yml
@@ -1,0 +1,53 @@
+id: tls-with-insecure-cipher-go
+language: go
+severity: warning
+message: >-
+  Detected an insecure CipherSuite via the 'tls' module. This suite is
+  considered weak. Use the function 'tls.CipherSuites()' to get a list of
+  good cipher suites. See
+  https://golang.org/pkg/crypto/tls/#InsecureCipherSuites for why and what
+  other cipher suites to use.
+note: >-
+  [CWE-327]: Use of a Broken or Risky Cryptographic Algorithm
+  [OWASP A03:2017]: Sensitive Data Exposure
+  [OWASP A02:2021]: Cryptographic Failures
+  [REFERENCES]
+       https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+utils:
+  match_tls_ciphersuite:
+    kind: literal_element
+    has:
+      stopBy: end
+      kind: composite_literal
+      all:
+        - has:
+            stopBy: end
+            kind: qualified_type
+            regex: ^(tls.CipherSuite)
+        - has:
+            stopBy: end
+            kind: literal_value
+            has:
+              stopBy: end
+              kind: literal_element
+              pattern: $R
+              regex: TLS_RSA_WITH_RC4_128_SHA|TLS_RSA_WITH_3DES_EDE_CBC_SHA|TLS_RSA_WITH_AES_128_CBC_SHA256|TLS_ECDHE_ECDSA_WITH_RC4_128_SHA|TLS_ECDHE_RSA_WITH_RC4_128_SHA|TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA|TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256|TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+  method_tls_config:
+    kind: composite_literal
+    all:
+      - has:
+          kind: qualified_type
+          regex: ^(tls.Config)
+      - has:
+          stopBy: end
+          kind: literal_value
+          has:
+            stopBy: end
+            kind: literal_element
+            pattern: $F
+            regex: tls.TLS_RSA_WITH_RC4_128_SHA|tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA|tls.TLS_RSA_WITH_AES_128_CBC_SHA256|tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA|tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA|tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA|tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256|tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+
+rule:
+  any:
+    - matches: match_tls_ciphersuite
+    - matches: method_tls_config

--- a/rules/java/security/blowfish-insufficient-key-size-java.yml
+++ b/rules/java/security/blowfish-insufficient-key-size-java.yml
@@ -1,0 +1,62 @@
+id: blowfish-insufficient-key-size-java
+severity: warning
+language: java
+message: >-
+  Using less than 128 bits for Blowfish is considered insecure. Use 128
+  bits or more, or switch to use AES instead.
+note: >-
+  [CWE-326] Inadequate Encryption Strength.
+  [REFERENCES]
+      - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+utils:
+  MATCH_PATTERN_KEYGENERATOR:
+    kind: expression_statement
+    all:
+      - has:
+          stopBy: end
+          kind: method_invocation
+          all:
+            - has:
+                stopBy: end
+                kind: identifier
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: '\binit\b'
+            - has:
+                stopBy: end
+                kind: argument_list
+                has:
+                  stopBy: end
+                  kind: decimal_integer_literal
+                  pattern: $R
+      - follows:
+          stopBy: end
+          kind: local_variable_declaration
+          has:
+            stopBy: end
+            kind: method_invocation
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  regex: '\bKeyGenerator\b'
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  regex: '\bgetInstance\b'
+              - has:
+                  stopBy: neighbor
+                  kind: argument_list
+                  has:
+                    stopBy: neighbor
+                    kind: string_literal
+                    regex: '\bBlowfish\b'
+
+rule:
+  kind: expression_statement
+  matches: MATCH_PATTERN_KEYGENERATOR
+
+constraints:
+  R:
+    regex: ^(?:[1-9]?[0-9]|1[01][0-9]|127)$

--- a/tests/__snapshots__/blowfish-insufficient-key-size-java-snapshot.yml
+++ b/tests/__snapshots__/blowfish-insufficient-key-size-java-snapshot.yml
@@ -1,0 +1,56 @@
+id: blowfish-insufficient-key-size-java
+snapshots:
+  ? |
+    public void unsafeKeySize() {
+       KeyGenerator keyGen = KeyGenerator.getInstance("Blowfish");
+       keyGen.init(64);
+    }
+  : labels:
+    - source: keyGen.init(64);
+      style: primary
+      start: 96
+      end: 112
+    - source: keyGen
+      style: secondary
+      start: 96
+      end: 102
+    - source: init
+      style: secondary
+      start: 103
+      end: 107
+    - source: '64'
+      style: secondary
+      start: 108
+      end: 110
+    - source: (64)
+      style: secondary
+      start: 107
+      end: 111
+    - source: keyGen.init(64)
+      style: secondary
+      start: 96
+      end: 111
+    - source: KeyGenerator
+      style: secondary
+      start: 55
+      end: 67
+    - source: getInstance
+      style: secondary
+      start: 68
+      end: 79
+    - source: '"Blowfish"'
+      style: secondary
+      start: 80
+      end: 90
+    - source: ("Blowfish")
+      style: secondary
+      start: 79
+      end: 91
+    - source: KeyGenerator.getInstance("Blowfish")
+      style: secondary
+      start: 55
+      end: 91
+    - source: KeyGenerator keyGen = KeyGenerator.getInstance("Blowfish");
+      style: secondary
+      start: 33
+      end: 92

--- a/tests/__snapshots__/tls-with-insecure-cipher-go-snapshot.yml
+++ b/tests/__snapshots__/tls-with-insecure-cipher-go-snapshot.yml
@@ -1,0 +1,38 @@
+id: tls-with-insecure-cipher-go
+snapshots:
+  ? |
+    tr := &http.Transport{
+    TLSClientConfig: &tls.Config{CipherSuites: []uint16{
+      tls.TLS_RSA_WITH_RC4_128_SHA,
+      tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+      }},
+    }
+  : labels:
+    - source: |-
+        tls.Config{CipherSuites: []uint16{
+          tls.TLS_RSA_WITH_RC4_128_SHA,
+          tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+          }}
+      style: primary
+      start: 41
+      end: 151
+    - source: tls.Config
+      style: secondary
+      start: 41
+      end: 51
+    - source: |-
+        []uint16{
+          tls.TLS_RSA_WITH_RC4_128_SHA,
+          tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+          }
+      style: secondary
+      start: 66
+      end: 150
+    - source: |-
+        {CipherSuites: []uint16{
+          tls.TLS_RSA_WITH_RC4_128_SHA,
+          tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+          }}
+      style: secondary
+      start: 51
+      end: 151

--- a/tests/go/tls-with-insecure-cipher-go-test.yml
+++ b/tests/go/tls-with-insecure-cipher-go-test.yml
@@ -1,0 +1,18 @@
+id: tls-with-insecure-cipher-go
+valid:
+  - |
+    tr := &http.Transport{
+    TLSClientConfig: &tls.Config{CipherSuites: []uint16{
+      tls.TLS_AES_128_GCM_SHA256,
+      tls.TLS_AES_256_GCM_SHA384,
+      }},
+    }
+
+invalid:
+  - |
+    tr := &http.Transport{
+    TLSClientConfig: &tls.Config{CipherSuites: []uint16{
+      tls.TLS_RSA_WITH_RC4_128_SHA,
+      tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+      }},
+    }

--- a/tests/java/blowfish-insufficient-key-size-java-test.yml
+++ b/tests/java/blowfish-insufficient-key-size-java-test.yml
@@ -1,0 +1,13 @@
+id: blowfish-insufficient-key-size-java
+valid:
+  - |
+    public void safeKeySize() {
+       KeyGenerator keyGen = KeyGenerator.getInstance("Blowfish");
+       keyGen.init(128);
+    }
+invalid:
+  - |
+    public void unsafeKeySize() {
+       KeyGenerator keyGen = KeyGenerator.getInstance("Blowfish");
+       keyGen.init(64);
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a rule to detect insecure TLS cipher suites in Go applications, promoting secure cryptographic practices.
  - Added a rule to identify inadequate key sizes for the Blowfish encryption algorithm in Java, advising on secure key sizes.

- **Tests**
  - Implemented test configurations to validate secure and insecure cipher suites in Go.
  - Created test cases for validating key sizes in Blowfish encryption, ensuring adherence to security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->