### PR TITLE
One change and one rule - file-access-before-action c/cpp

### DIFF
--- a/rules/c/security/file-access-before-action-c.yml
+++ b/rules/c/security/file-access-before-action-c.yml
@@ -13,60 +13,75 @@ utils:
   match_unlink_identifier:
     kind: identifier
     regex: unlink|fopen|freopen|remove|rename|access|open|stat|lstat|unlink|mkdir|rmdir|chdir|folly::readFile|folly::writeFile|folly::writeFileAtomic|folly::writeFileAtomicNoThrow|folly::File
-    inside:
-      kind: call_expression
-      inside:
-        kind: expression_statement
-        inside:
-          kind: compound_statement
+    all:
+      - inside:
+          kind: call_expression
           inside:
-            stopBy: end
-            kind: if_statement
-            has:
-              stopBy: end
-              kind: call_expression
-              all:
-                - has:
-                    kind: identifier
-                    pattern: $R
-                - has:
-                    kind: argument_list
-                    all:
-                      - has:
-                          kind: identifier
-                          regex: ^original_key
-                      - has:
-                          kind: identifier
-                          regex: F_OK|R_OK|W_OK|X_OK
+            kind: expression_statement
+            inside:
+              kind: compound_statement
+              inside:
+                stopBy: end
+                kind: if_statement
+                has:
+                  stopBy: end
+                  kind: call_expression
+                  all:
+                    - has:
+                        kind: identifier
+                        pattern: $R
+                    - has:
+                        kind: argument_list
+                        all:
+                          - has:
+                              kind: identifier
+                              pattern: $O
+                          - has:
+                              kind: identifier
+                              regex: F_OK|R_OK|W_OK|X_OK
+      - precedes:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: neighbor
+            kind: identifier
+            pattern: $O
 
   match_fopen_identifier:
     kind: identifier
     regex: unlink|fopen|freopen|remove|rename|access|open|stat|lstat|unlink|mkdir|rmdir|chdir|folly::readFile|folly::writeFile|folly::writeFileAtomic|folly::writeFileAtomicNoThrow|folly::File
-    inside:
-      kind: call_expression
-      inside:
-        stopBy: end
-        kind: compound_statement
-        inside:
-          stopBy: end
-          kind: if_statement
-          has:
+    all:
+      - inside:
+          kind: call_expression
+          inside:
             stopBy: end
-            kind: call_expression
-            all:
-              - has:
-                  kind: identifier
-                  pattern: $L
-              - has:
-                  kind: argument_list
-                  all:
-                    - has:
-                        kind: identifier
-                        regex: ^original_key
-                    - has:
-                        kind: identifier
-                        regex: F_OK|R_OK|W_OK|X_OK
-
+            kind: compound_statement
+            inside:
+              stopBy: end
+              kind: if_statement
+              has:
+                stopBy: end
+                kind: call_expression
+                all:
+                  - has:
+                      kind: identifier
+                      pattern: $L
+                  - has:
+                      kind: argument_list
+                      all:
+                        - has:
+                            kind: identifier
+                            pattern: $O
+                        - has:
+                            kind: identifier
+                            regex: F_OK|R_OK|W_OK|X_OK
+      - precedes:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: neighbor
+            kind: identifier
+            pattern: $O
 rule:
   any:
     - matches: match_unlink_identifier

--- a/rules/c/security/file-access-before-action-c.yml
+++ b/rules/c/security/file-access-before-action-c.yml
@@ -1,0 +1,78 @@
+id: file-access-before-action-c
+language: c
+severity: warning
+message: >-
+  A check is done with `access` and then the file is later used. There is
+  no guarantee that the status of the file has not changed since the call to
+  `access` which may allow attackers to bypass permission checks.
+note: >-
+  [CWE-367]: Time-of-check Time-of-use (TOCTOU) Race Condition
+  [REFERENCES]
+      - https://wiki.sei.cmu.edu/confluence/display/c/FIO45-C.+Avoid+TOCTOU+race+conditions+while+accessing+files
+utils:
+  match_unlink_identifier:
+    kind: identifier
+    regex: unlink|fopen|freopen|remove|rename|access|open|stat|lstat|unlink|mkdir|rmdir|chdir|folly::readFile|folly::writeFile|folly::writeFileAtomic|folly::writeFileAtomicNoThrow|folly::File
+    inside:
+      kind: call_expression
+      inside:
+        kind: expression_statement
+        inside:
+          kind: compound_statement
+          inside:
+            stopBy: end
+            kind: if_statement
+            has:
+              stopBy: end
+              kind: call_expression
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $R
+                - has:
+                    kind: argument_list
+                    all:
+                      - has:
+                          kind: identifier
+                          regex: ^original_key
+                      - has:
+                          kind: identifier
+                          regex: F_OK|R_OK|W_OK|X_OK
+
+  match_fopen_identifier:
+    kind: identifier
+    regex: unlink|fopen|freopen|remove|rename|access|open|stat|lstat|unlink|mkdir|rmdir|chdir|folly::readFile|folly::writeFile|folly::writeFileAtomic|folly::writeFileAtomicNoThrow|folly::File
+    inside:
+      kind: call_expression
+      inside:
+        stopBy: end
+        kind: compound_statement
+        inside:
+          stopBy: end
+          kind: if_statement
+          has:
+            stopBy: end
+            kind: call_expression
+            all:
+              - has:
+                  kind: identifier
+                  pattern: $L
+              - has:
+                  kind: argument_list
+                  all:
+                    - has:
+                        kind: identifier
+                        regex: ^original_key
+                    - has:
+                        kind: identifier
+                        regex: F_OK|R_OK|W_OK|X_OK
+
+rule:
+  any:
+    - matches: match_unlink_identifier
+    - matches: match_fopen_identifier
+constraints:
+  R:
+    regex: ^(access|faccessat|faccessat2|)$
+  L:
+    regex: ^(access|faccessat|faccessat2|)$

--- a/rules/cpp/file-access-before-action-cpp.yml
+++ b/rules/cpp/file-access-before-action-cpp.yml
@@ -1,0 +1,78 @@
+id: file-access-before-action-cpp
+language: cpp
+severity: warning
+message: >-
+  A check is done with `access` and then the file is later used. There is
+  no guarantee that the status of the file has not changed since the call to
+  `access` which may allow attackers to bypass permission checks.
+note: >-
+  [CWE-367]: Time-of-check Time-of-use (TOCTOU) Race Condition
+  [REFERENCES]
+      - https://wiki.sei.cmu.edu/confluence/display/c/FIO45-C.+Avoid+TOCTOU+race+conditions+while+accessing+files
+utils:
+  match_unlink_identifier:
+    kind: identifier
+    regex: unlink|fopen|freopen|remove|rename|access|open|stat|lstat|unlink|mkdir|rmdir|chdir|folly::readFile|folly::writeFile|folly::writeFileAtomic|folly::writeFileAtomicNoThrow|folly::File
+    inside:
+      kind: call_expression
+      inside:
+        kind: expression_statement
+        inside:
+          kind: compound_statement
+          inside:
+            stopBy: end
+            kind: if_statement
+            has:
+              stopBy: end
+              kind: call_expression
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $R
+                - has:
+                    kind: argument_list
+                    all:
+                      - has:
+                          kind: identifier
+                          regex: ^original_key
+                      - has:
+                          kind: identifier
+                          regex: F_OK|R_OK|W_OK|X_OK
+
+  match_fopen_identifier:
+    kind: identifier
+    regex: unlink|fopen|freopen|remove|rename|access|open|stat|lstat|unlink|mkdir|rmdir|chdir|folly::readFile|folly::writeFile|folly::writeFileAtomic|folly::writeFileAtomicNoThrow|folly::File
+    inside:
+      kind: call_expression
+      inside:
+        stopBy: end
+        kind: compound_statement
+        inside:
+          stopBy: end
+          kind: if_statement
+          has:
+            stopBy: end
+            kind: call_expression
+            all:
+              - has:
+                  kind: identifier
+                  pattern: $L
+              - has:
+                  kind: argument_list
+                  all:
+                    - has:
+                        kind: identifier
+                        regex: ^original_key
+                    - has:
+                        kind: identifier
+                        regex: F_OK|R_OK|W_OK|X_OK
+
+rule:
+  any:
+    - matches: match_unlink_identifier
+    - matches: match_fopen_identifier
+constraints:
+  R:
+    regex: ^(access|faccessat|faccessat2|)$
+  L:
+    regex: ^(access|faccessat|faccessat2|)$

--- a/rules/cpp/file-access-before-action-cpp.yml
+++ b/rules/cpp/file-access-before-action-cpp.yml
@@ -13,60 +13,75 @@ utils:
   match_unlink_identifier:
     kind: identifier
     regex: unlink|fopen|freopen|remove|rename|access|open|stat|lstat|unlink|mkdir|rmdir|chdir|folly::readFile|folly::writeFile|folly::writeFileAtomic|folly::writeFileAtomicNoThrow|folly::File
-    inside:
-      kind: call_expression
-      inside:
-        kind: expression_statement
-        inside:
-          kind: compound_statement
+    all:
+      - inside:
+          kind: call_expression
           inside:
-            stopBy: end
-            kind: if_statement
-            has:
-              stopBy: end
-              kind: call_expression
-              all:
-                - has:
-                    kind: identifier
-                    pattern: $R
-                - has:
-                    kind: argument_list
-                    all:
-                      - has:
-                          kind: identifier
-                          regex: ^original_key
-                      - has:
-                          kind: identifier
-                          regex: F_OK|R_OK|W_OK|X_OK
+            kind: expression_statement
+            inside:
+              kind: compound_statement
+              inside:
+                stopBy: end
+                kind: if_statement
+                has:
+                  stopBy: end
+                  kind: call_expression
+                  all:
+                    - has:
+                        kind: identifier
+                        pattern: $R
+                    - has:
+                        kind: argument_list
+                        all:
+                          - has:
+                              kind: identifier
+                              pattern: $O
+                          - has:
+                              kind: identifier
+                              regex: F_OK|R_OK|W_OK|X_OK
+      - precedes:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: neighbor
+            kind: identifier
+            pattern: $O
 
   match_fopen_identifier:
     kind: identifier
     regex: unlink|fopen|freopen|remove|rename|access|open|stat|lstat|unlink|mkdir|rmdir|chdir|folly::readFile|folly::writeFile|folly::writeFileAtomic|folly::writeFileAtomicNoThrow|folly::File
-    inside:
-      kind: call_expression
-      inside:
-        stopBy: end
-        kind: compound_statement
-        inside:
-          stopBy: end
-          kind: if_statement
-          has:
+    all:
+      - inside:
+          kind: call_expression
+          inside:
             stopBy: end
-            kind: call_expression
-            all:
-              - has:
-                  kind: identifier
-                  pattern: $L
-              - has:
-                  kind: argument_list
-                  all:
-                    - has:
-                        kind: identifier
-                        regex: ^original_key
-                    - has:
-                        kind: identifier
-                        regex: F_OK|R_OK|W_OK|X_OK
-
+            kind: compound_statement
+            inside:
+              stopBy: end
+              kind: if_statement
+              has:
+                stopBy: end
+                kind: call_expression
+                all:
+                  - has:
+                      kind: identifier
+                      pattern: $L
+                  - has:
+                      kind: argument_list
+                      all:
+                        - has:
+                            kind: identifier
+                            pattern: $O
+                        - has:
+                            kind: identifier
+                            regex: F_OK|R_OK|W_OK|X_OK
+      - precedes:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: neighbor
+            kind: identifier
+            pattern: $O
 rule:
   any:
     - matches: match_unlink_identifier

--- a/tests/__snapshots__/file-access-before-action-c-snapshot.yml
+++ b/tests/__snapshots__/file-access-before-action-c-snapshot.yml
@@ -1,0 +1,79 @@
+id: file-access-before-action-c
+snapshots:
+  ? |
+    {
+    const char *original_key = "path/to/file/filename";
+    const char *mirror_key = "path/to/another/file/filename";
+
+    if ((access(original_key, F_OK) == 0) && (access(mirror_key, F_OK) == 0))
+    {
+        copy_file("/bin/cp %s %s", original_key, mirror_key);
+
+        // ruleid: file-access-before-action
+        unlink(original_key);
+    }
+    }
+    void test_002()
+    {
+    const char *original_key = "path/to/file/filename";
+
+    if (access(original_key, W_OK) == 0)
+    {
+        // ruleid: file-access-before-action
+        FILe *fp = fopen(original_key, "wb");
+    }
+    }
+  : labels:
+    - source: unlink
+      style: primary
+      start: 293
+      end: 299
+    - source: access
+      style: secondary
+      start: 118
+      end: 124
+    - source: original_key
+      style: secondary
+      start: 125
+      end: 137
+    - source: F_OK
+      style: secondary
+      start: 139
+      end: 143
+    - source: (original_key, F_OK)
+      style: secondary
+      start: 124
+      end: 144
+    - source: access(original_key, F_OK)
+      style: secondary
+      start: 118
+      end: 144
+    - source: |-
+        if ((access(original_key, F_OK) == 0) && (access(mirror_key, F_OK) == 0))
+        {
+            copy_file("/bin/cp %s %s", original_key, mirror_key);
+
+            // ruleid: file-access-before-action
+            unlink(original_key);
+        }
+      style: secondary
+      start: 113
+      end: 316
+    - source: |-
+        {
+            copy_file("/bin/cp %s %s", original_key, mirror_key);
+
+            // ruleid: file-access-before-action
+            unlink(original_key);
+        }
+      style: secondary
+      start: 187
+      end: 316
+    - source: unlink(original_key);
+      style: secondary
+      start: 293
+      end: 314
+    - source: unlink(original_key)
+      style: secondary
+      start: 293
+      end: 313

--- a/tests/__snapshots__/file-access-before-action-c-snapshot.yml
+++ b/tests/__snapshots__/file-access-before-action-c-snapshot.yml
@@ -77,3 +77,11 @@ snapshots:
       style: secondary
       start: 293
       end: 313
+    - source: original_key
+      style: secondary
+      start: 300
+      end: 312
+    - source: (original_key)
+      style: secondary
+      start: 299
+      end: 313

--- a/tests/__snapshots__/file-access-before-action-cpp-snapshot.yml
+++ b/tests/__snapshots__/file-access-before-action-cpp-snapshot.yml
@@ -77,3 +77,11 @@ snapshots:
       style: secondary
       start: 293
       end: 313
+    - source: original_key
+      style: secondary
+      start: 300
+      end: 312
+    - source: (original_key)
+      style: secondary
+      start: 299
+      end: 313

--- a/tests/__snapshots__/file-access-before-action-cpp-snapshot.yml
+++ b/tests/__snapshots__/file-access-before-action-cpp-snapshot.yml
@@ -1,0 +1,79 @@
+id: file-access-before-action-cpp
+snapshots:
+  ? |
+    {
+    const char *original_key = "path/to/file/filename";
+    const char *mirror_key = "path/to/another/file/filename";
+
+    if ((access(original_key, F_OK) == 0) && (access(mirror_key, F_OK) == 0))
+    {
+        copy_file("/bin/cp %s %s", original_key, mirror_key);
+
+        // ruleid: file-access-before-action
+        unlink(original_key);
+    }
+    }
+    void test_002()
+    {
+    const char *original_key = "path/to/file/filename";
+
+    if (access(original_key, W_OK) == 0)
+    {
+        // ruleid: file-access-before-action
+        FILe *fp = fopen(original_key, "wb");
+    }
+    }
+  : labels:
+    - source: unlink
+      style: primary
+      start: 293
+      end: 299
+    - source: access
+      style: secondary
+      start: 118
+      end: 124
+    - source: original_key
+      style: secondary
+      start: 125
+      end: 137
+    - source: F_OK
+      style: secondary
+      start: 139
+      end: 143
+    - source: (original_key, F_OK)
+      style: secondary
+      start: 124
+      end: 144
+    - source: access(original_key, F_OK)
+      style: secondary
+      start: 118
+      end: 144
+    - source: |-
+        if ((access(original_key, F_OK) == 0) && (access(mirror_key, F_OK) == 0))
+        {
+            copy_file("/bin/cp %s %s", original_key, mirror_key);
+
+            // ruleid: file-access-before-action
+            unlink(original_key);
+        }
+      style: secondary
+      start: 113
+      end: 316
+    - source: |-
+        {
+            copy_file("/bin/cp %s %s", original_key, mirror_key);
+
+            // ruleid: file-access-before-action
+            unlink(original_key);
+        }
+      style: secondary
+      start: 187
+      end: 316
+    - source: unlink(original_key);
+      style: secondary
+      start: 293
+      end: 314
+    - source: unlink(original_key)
+      style: secondary
+      start: 293
+      end: 313

--- a/tests/c/file-access-before-action-c-test.yml
+++ b/tests/c/file-access-before-action-c-test.yml
@@ -1,0 +1,28 @@
+id: file-access-before-action-c
+valid:
+  - |
+
+invalid:
+  - |
+    {
+    const char *original_key = "path/to/file/filename";
+    const char *mirror_key = "path/to/another/file/filename";
+
+    if ((access(original_key, F_OK) == 0) && (access(mirror_key, F_OK) == 0))
+    {
+        copy_file("/bin/cp %s %s", original_key, mirror_key);
+
+        // ruleid: file-access-before-action
+        unlink(original_key);
+    }
+    }
+    void test_002()
+    {
+    const char *original_key = "path/to/file/filename";
+
+    if (access(original_key, W_OK) == 0)
+    {
+        // ruleid: file-access-before-action
+        FILe *fp = fopen(original_key, "wb");
+    }
+    }

--- a/tests/cpp/file-access-before-action-cpp-test.yml
+++ b/tests/cpp/file-access-before-action-cpp-test.yml
@@ -1,0 +1,28 @@
+id: file-access-before-action-cpp
+valid:
+  - |
+
+invalid:
+  - |
+    {
+    const char *original_key = "path/to/file/filename";
+    const char *mirror_key = "path/to/another/file/filename";
+
+    if ((access(original_key, F_OK) == 0) && (access(mirror_key, F_OK) == 0))
+    {
+        copy_file("/bin/cp %s %s", original_key, mirror_key);
+
+        // ruleid: file-access-before-action
+        unlink(original_key);
+    }
+    }
+    void test_002()
+    {
+    const char *original_key = "path/to/file/filename";
+
+    if (access(original_key, W_OK) == 0)
+    {
+        // ruleid: file-access-before-action
+        FILe *fp = fopen(original_key, "wb");
+    }
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced rules to detect potential Time-of-check Time-of-use (TOCTOU) race conditions in C and C++ file access operations, enhancing security by warning against improper file handling practices.
  
- **Tests**
  - Added comprehensive test cases for both C and C++ to validate file access operations, ensuring adherence to the new rules and highlighting potential vulnerabilities in file handling.

These updates improve the static analysis capabilities of our tools, helping developers identify and mitigate security risks associated with file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->