### PR TITLE
Two Rust rules 16Oct2024

### DIFF
--- a/rules/rust/security/postgres-empty-password-rust.yml
+++ b/rules/rust/security/postgres-empty-password-rust.yml
@@ -1,0 +1,124 @@
+id: postgres-empty-password-rust
+language: rust
+severity: warning
+message: >-
+  The application uses an empty credential. This can lead to unauthorized
+  access by either an internal or external malicious actor. It is
+  recommended to rotate the secret and retrieve them from a secure secret
+  vault or Hardware Security Module (HSM), alternatively environment
+  variables can be used if allowed by your company policy.
+note: >-
+  [CWE-287] Improper Authentication.
+  [REFERENCES]
+      - https://docs.rs/postgres/latest/postgres/
+      - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+utils:
+  MATCH_PATTERN_WITH_INSTANCE:
+    kind: call_expression
+    all:
+      - has:
+          stopBy: neighbor
+          kind: field_expression
+          all:
+            - has:
+                stopBy: neighbor
+                kind: call_expression
+                all:
+                  - has:
+                      stopBy: neighbor
+                      kind: field_expression
+                      all:
+                        - has:
+                            stopBy: end
+                            kind: call_expression
+                            all:
+                              - has:
+                                  stopBy: neighbor
+                                  kind: field_expression
+                                  all:
+                                    - has:
+                                        stopBy: neighbor
+                                        kind: identifier
+                                        pattern: $C
+                              - has:
+                                  stopBy: neighbor
+                                  kind: arguments
+                        - has:
+                            stopBy: neighbor
+                            kind: field_identifier
+                  - has:
+                      stopBy: neighbor
+                      kind: arguments
+            - has:
+                stopBy: neighbor
+                kind: field_identifier
+                regex: "^password$"
+      - has:
+          stopBy: neighbor
+          kind: arguments
+          regex: \(\s*\"\"\s*\)
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: let_declaration
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $C
+              - has:
+                  stopBy: neighbor
+                  kind: call_expression
+                  pattern: postgres::Config::new()
+
+  MATCH_PATTERN_DIRECTLY:
+    kind: call_expression
+    all:
+      - has:
+          stopBy: neighbor
+          kind: field_expression
+          all:
+            - has:
+                stopBy: neighbor
+                kind: call_expression
+                all:
+                  - has:
+                      stopBy: neighbor
+                      kind: field_expression
+                      all:
+                        - has:
+                            stopBy: neighbor
+                            kind: call_expression
+                            all:
+                              - has:
+                                  stopBy: neighbor
+                                  kind: field_expression
+                                  has:
+                                    stopBy: neighbor
+                                    kind: call_expression
+                                    pattern: postgres::Config::new()
+                              - has:
+                                  stopBy: neighbor
+                                  kind: arguments
+                        - has:
+                            stopBy: neighbor
+                            kind: field_identifier
+                  - has:
+                      stopBy: neighbor
+                      kind: arguments
+            - has:
+                stopBy: neighbor
+                kind: field_identifier
+                regex: "^password$"
+      - has:
+          stopBy: neighbor
+          kind: arguments
+          regex: \(\s*\"\"\s*\)
+
+rule:
+  kind: call_expression
+  any:
+    - matches: MATCH_PATTERN_WITH_INSTANCE
+    - matches: MATCH_PATTERN_DIRECTLY

--- a/rules/rust/security/postgres-empty-password-rust.yml
+++ b/rules/rust/security/postgres-empty-password-rust.yml
@@ -10,8 +10,8 @@ message: >-
 note: >-
   [CWE-287] Improper Authentication.
   [REFERENCES]
-      - https://docs.rs/postgres/latest/postgres/
-      - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+  - https://docs.rs/postgres/latest/postgres/
+  - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
 utils:
   MATCH_PATTERN_WITH_INSTANCE:
     kind: call_expression

--- a/rules/rust/security/secrets-reqwest-hardcoded-auth-rust.yml
+++ b/rules/rust/security/secrets-reqwest-hardcoded-auth-rust.yml
@@ -1,0 +1,138 @@
+id: secrets-reqwest-hardcoded-auth-rust
+language: rust
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source
+  code, such as credentials, identifiers, and other types of sensitive data,
+  can be leaked and used by internal or external malicious actors. It is
+  recommended to rotate the secret and retrieve them from a secure secret
+  vault or Hardware Security Module (HSM), alternatively environment
+  variables can be used if allowed by your company policy.
+note: >-
+  [CWE-798] Use of Hard-coded Credentials.
+  [REFERENCES]
+      - https://docs.rs/reqwest/latest/reqwest/
+      - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+utils:
+  MATCH_PATTERN_ONE:
+    kind: call_expression
+    all:
+      - has:
+          stopBy: neighbor
+          kind: field_expression
+          all:
+            - has:
+                stopBy: neighbor
+                kind: call_expression
+                has:
+                  stopBy: neighbor
+                  kind: field_expression
+                  all:
+                    - has:
+                        stopBy: neighbor
+                        kind: identifier
+                        pattern: $C
+            - has:
+                stopBy: neighbor
+                kind: field_identifier
+                regex: "^bearer_auth|basic_auth$"
+      - has:
+          stopBy: neighbor
+          kind: arguments
+          all:
+            - has:
+                stopBy: neighbor
+                kind: string_literal
+                has:
+                  stopBy: neighbor
+                  kind: string_content
+            - has:
+                stopBy: neighbor
+                kind: call_expression
+                all:
+                  - has:
+                      stopBy: neighbor
+                      kind: identifier
+                      regex: "^Some$"
+                  - has:
+                      stopBy: neighbor
+                      kind: arguments
+                      has:
+                        stopBy: neighbor
+                        kind: string_literal
+                        has:
+                          stopBy: neighbor
+                          kind: string_content
+
+      - inside:
+          stopBy: end
+          kind: let_declaration
+          follows:
+            stopBy: end
+            kind: let_declaration
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $C
+              - has:
+                  stopBy: neighbor
+                  kind: call_expression
+                  pattern: reqwest::Client::new($$$)
+
+  MATCH_PATTERN_TWO:
+    kind: call_expression
+    all:
+      - has:
+          stopBy: neighbor
+          kind: field_expression
+          all:
+            - has:
+                stopBy: neighbor
+                kind: call_expression
+                has:
+                  stopBy: neighbor
+                  kind: field_expression
+                  all:
+                    - has:
+                        stopBy: neighbor
+                        kind: identifier
+                        pattern: $C
+            - has:
+                stopBy: neighbor
+                kind: field_identifier
+                regex: "^bearer_auth|basic_auth$"
+      - inside:
+          stopBy: end
+          kind: let_declaration
+          follows:
+            stopBy: end
+            kind: let_declaration
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $C
+              - has:
+                  stopBy: neighbor
+                  kind: call_expression
+                  pattern: reqwest::Client::new($$$)
+      - has:
+          stopBy: neighbor
+          kind: arguments
+          all:
+            - has:
+                stopBy: neighbor
+                kind: string_literal
+                has:
+                  stopBy: neighbor
+                  kind: string_content
+            - not:
+                has:
+                  kind: call_expression
+
+rule:
+  kind: call_expression
+  any:
+    - matches: MATCH_PATTERN_ONE
+    - matches: MATCH_PATTERN_TWO

--- a/tests/__snapshots__/postgres-empty-password-rust-snapshot.yml
+++ b/tests/__snapshots__/postgres-empty-password-rust-snapshot.yml
@@ -1,0 +1,101 @@
+id: postgres-empty-password-rust
+snapshots:
+  ? |
+    fn test1() {
+    let mut config = postgres::Config::new();
+    config
+    .host(std::env::var("HOST").expect("set HOST"))
+    .user(std::env::var("USER").expect("set USER"))
+    .password("")
+    .port(std::env::var("PORT").expect("set PORT"));
+    let (client, connection) = config.connect(NoTls);
+    Ok(())
+    }
+  : labels:
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user(std::env::var("USER").expect("set USER"))
+        .password("")
+      style: primary
+      start: 55
+      end: 171
+    - source: config
+      style: secondary
+      start: 55
+      end: 61
+    - source: |-
+        config
+        .host
+      style: secondary
+      start: 55
+      end: 67
+    - source: (std::env::var("HOST").expect("set HOST"))
+      style: secondary
+      start: 67
+      end: 109
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+      style: secondary
+      start: 55
+      end: 109
+    - source: user
+      style: secondary
+      start: 111
+      end: 115
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user
+      style: secondary
+      start: 55
+      end: 115
+    - source: (std::env::var("USER").expect("set USER"))
+      style: secondary
+      start: 115
+      end: 157
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user(std::env::var("USER").expect("set USER"))
+      style: secondary
+      start: 55
+      end: 157
+    - source: password
+      style: secondary
+      start: 159
+      end: 167
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user(std::env::var("USER").expect("set USER"))
+        .password
+      style: secondary
+      start: 55
+      end: 167
+    - source: ("")
+      style: secondary
+      start: 167
+      end: 171
+    - source: config
+      style: secondary
+      start: 21
+      end: 27
+    - source: postgres::Config::new()
+      style: secondary
+      start: 30
+      end: 53
+    - source: let mut config = postgres::Config::new();
+      style: secondary
+      start: 13
+      end: 54
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user(std::env::var("USER").expect("set USER"))
+        .password("")
+        .port(std::env::var("PORT").expect("set PORT"));
+      style: secondary
+      start: 55
+      end: 220

--- a/tests/__snapshots__/secrets-reqwest-hardcoded-auth-rust-snapshot.yml
+++ b/tests/__snapshots__/secrets-reqwest-hardcoded-auth-rust-snapshot.yml
@@ -1,0 +1,102 @@
+id: secrets-reqwest-hardcoded-auth-rust
+snapshots:
+  ? |
+    async fn test1() -> Result<(), reqwest::Error> {
+    let client = reqwest::Client::new();
+    let resp = client.delete("http://httpbin.org/delete")
+    .basic_auth("admin", Some("hardcoded-password"))
+    .send()
+    .await?;
+    println!("body = {:?}", resp);
+    Ok(())
+    }
+    async fn test2() -> Result<(), reqwest::Error> {
+    let client = reqwest::Client::new();
+    let resp = client.put("http://httpbin.org/delete")
+    .bearer_auth("hardcoded-token")
+    .send()
+    .await?;
+    println!("body = {:?}", resp);
+    Ok(())
+    }
+  : labels:
+    - source: |-
+        client.delete("http://httpbin.org/delete")
+        .basic_auth("admin", Some("hardcoded-password"))
+      style: primary
+      start: 97
+      end: 188
+    - source: client
+      style: secondary
+      start: 97
+      end: 103
+    - source: client.delete
+      style: secondary
+      start: 97
+      end: 110
+    - source: client.delete("http://httpbin.org/delete")
+      style: secondary
+      start: 97
+      end: 139
+    - source: basic_auth
+      style: secondary
+      start: 141
+      end: 151
+    - source: |-
+        client.delete("http://httpbin.org/delete")
+        .basic_auth
+      style: secondary
+      start: 97
+      end: 151
+    - source: admin
+      style: secondary
+      start: 153
+      end: 158
+    - source: '"admin"'
+      style: secondary
+      start: 152
+      end: 159
+    - source: Some
+      style: secondary
+      start: 161
+      end: 165
+    - source: hardcoded-password
+      style: secondary
+      start: 167
+      end: 185
+    - source: '"hardcoded-password"'
+      style: secondary
+      start: 166
+      end: 186
+    - source: ("hardcoded-password")
+      style: secondary
+      start: 165
+      end: 187
+    - source: Some("hardcoded-password")
+      style: secondary
+      start: 161
+      end: 187
+    - source: ("admin", Some("hardcoded-password"))
+      style: secondary
+      start: 151
+      end: 188
+    - source: client
+      style: secondary
+      start: 53
+      end: 59
+    - source: reqwest::Client::new()
+      style: secondary
+      start: 62
+      end: 84
+    - source: let client = reqwest::Client::new();
+      style: secondary
+      start: 49
+      end: 85
+    - source: |-
+        let resp = client.delete("http://httpbin.org/delete")
+        .basic_auth("admin", Some("hardcoded-password"))
+        .send()
+        .await?;
+      style: secondary
+      start: 86
+      end: 205

--- a/tests/rust/postgres-empty-password-rust-test.yml
+++ b/tests/rust/postgres-empty-password-rust-test.yml
@@ -1,0 +1,29 @@
+id: postgres-empty-password-rust
+valid:
+  - |
+    async fn okTest2() {
+    let (client, connection) = postgres::Config::new()
+    .host(shard_host_name.as_str())
+    .user("postgres")
+    .password("postgres")
+    .dbname("ninja")
+    .keepalives_idle(std::time::Duration::from_secs(30))
+    .connect(NoTls)
+    .map_err(|e| {
+    error!(log, "failed to connect to {}: {}", &shard_host_name, e);
+    Error::new(ErrorKind::Other, e)
+    })?;
+     Ok(())
+     }
+invalid:
+  - |
+    fn test1() {
+    let mut config = postgres::Config::new();
+    config
+    .host(std::env::var("HOST").expect("set HOST"))
+    .user(std::env::var("USER").expect("set USER"))
+    .password("")
+    .port(std::env::var("PORT").expect("set PORT"));
+    let (client, connection) = config.connect(NoTls);
+    Ok(())
+    }

--- a/tests/rust/secrets-reqwest-hardcoded-auth-rust-test.yml
+++ b/tests/rust/secrets-reqwest-hardcoded-auth-rust-test.yml
@@ -1,0 +1,32 @@
+id: secrets-reqwest-hardcoded-auth-rust
+valid:
+  - |
+    async fn test1(pass: &str) -> Result<(), reqwest::Error> {
+    let client = reqwest::Client::new();
+    let resp = client.delete("http://httpbin.org/delete")
+    .basic_auth("admin", Some(pass))
+    .send()
+    .await?;
+    println!("body = {:?}", resp);
+    Ok(())
+    }
+invalid:
+  - |
+    async fn test1() -> Result<(), reqwest::Error> {
+    let client = reqwest::Client::new();
+    let resp = client.delete("http://httpbin.org/delete")
+    .basic_auth("admin", Some("hardcoded-password"))
+    .send()
+    .await?;
+    println!("body = {:?}", resp);
+    Ok(())
+    }
+    async fn test2() -> Result<(), reqwest::Error> {
+    let client = reqwest::Client::new();
+    let resp = client.put("http://httpbin.org/delete")
+    .bearer_auth("hardcoded-token")
+    .send()
+    .await?;
+    println!("body = {:?}", resp);
+    Ok(())
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a rule to detect empty passwords in PostgreSQL configurations for Rust applications.
	- Added a rule to identify hard-coded secrets in Rust applications using the `reqwest` library.

- **Tests**
	- Implemented test cases for validating PostgreSQL connections, including scenarios with empty passwords.
	- Created tests to evaluate authentication methods in HTTP requests, contrasting valid dynamic authentication with invalid hardcoded credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->