### PR TITLE
Rule - avoid_app_run_with_bad_host-python

### DIFF
--- a/rules/python/security/avoid_app_run_with_bad_host-python.yml
+++ b/rules/python/security/avoid_app_run_with_bad_host-python.yml
@@ -1,0 +1,73 @@
+id: avoid_app_run_with_bad_host-python
+language: python
+severity: warning
+message: >-
+  Running flask app with host 0.0.0.0 could expose the server publicly.
+note: >-
+  [CWE-668]: Exposure of Resource to Wrong Sphere
+  [OWASP A01:2021]: Broken Access Control
+  [REFERENCES]
+       https://owasp.org/Top10/A01_2021-Broken_Access_Control
+utils:
+  MATCH_PATTERN_app.run:
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: "^app$"
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: "^run$"
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: neighbor
+            kind: string
+            regex: ^"0.0.0.0"$
+
+  MATCH_PATTERN_app.run_HOST:
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: "^app$"
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: "^run$"
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: neighbor
+            kind: keyword_argument
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  regex: "^host$"
+              - has:
+                  stopBy: neighbor
+                  kind: string
+                  regex: ^"0.0.0.0"$
+              - has:
+                  stopBy: neighbor
+                  regex: "^=$"
+
+rule:
+  kind: call
+  any:
+    - matches: MATCH_PATTERN_app.run
+    - matches: MATCH_PATTERN_app.run_HOST

--- a/tests/__snapshots__/avoid_app_run_with_bad_host-python-snapshot.yml
+++ b/tests/__snapshots__/avoid_app_run_with_bad_host-python-snapshot.yml
@@ -1,0 +1,42 @@
+id: avoid_app_run_with_bad_host-python
+snapshots:
+  ? |
+    app.run(host="0.0.0.0")
+    app.run("0.0.0.0")
+  : labels:
+    - source: app.run(host="0.0.0.0")
+      style: primary
+      start: 0
+      end: 23
+    - source: app
+      style: secondary
+      start: 0
+      end: 3
+    - source: run
+      style: secondary
+      start: 4
+      end: 7
+    - source: app.run
+      style: secondary
+      start: 0
+      end: 7
+    - source: host
+      style: secondary
+      start: 8
+      end: 12
+    - source: '"0.0.0.0"'
+      style: secondary
+      start: 13
+      end: 22
+    - source: =
+      style: secondary
+      start: 12
+      end: 13
+    - source: host="0.0.0.0"
+      style: secondary
+      start: 8
+      end: 22
+    - source: (host="0.0.0.0")
+      style: secondary
+      start: 7
+      end: 23

--- a/tests/python/avoid_app_run_with_bad_host-python-test.yml
+++ b/tests/python/avoid_app_run_with_bad_host-python-test.yml
@@ -1,0 +1,8 @@
+id: avoid_app_run_with_bad_host-python
+valid:
+  - |
+    foo.run("0.0.0.0")
+invalid:
+  - |
+    app.run(host="0.0.0.0")
+    app.run("0.0.0.0")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new security rule to warn against running Flask applications with the host set to `0.0.0.0`, enhancing security awareness for developers.
	- Added validation tests to ensure proper usage of the `run` method in Python applications.

- **Tests**
	- Added snapshots and test cases to validate the new security rule and its configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->