### PR TITLE
Add Security Rules for Database Connections and SSL Configurations in Rust

### DIFF
--- a/rules/rust/security/postgres-empty-password-rust.yml
+++ b/rules/rust/security/postgres-empty-password-rust.yml
@@ -1,0 +1,292 @@
+id: postgres-empty-password-rust
+language: rust
+severity: warning
+message: >-
+  The application uses an empty credential. This can lead to unauthorized
+  access by either an internal or external malicious actor. It is
+  recommended to rotate the secret and retrieve them from a secure secret
+  vault or Hardware Security Module (HSM), alternatively environment
+  variables can be used if allowed by your company policy.
+note: >-
+  [CWE-287] Improper Authentication.
+  [REFERENCES]
+  - https://docs.rs/postgres/latest/postgres/
+  - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+utils:
+  MATCH_PATTERN_WITH_INSTANCE:
+    kind: call_expression
+    all:
+      - has:
+          stopBy: neighbor
+          kind: field_expression
+          all:
+            - has:
+                  stopBy: neighbor
+                  kind: call_expression
+                  all:
+                    - has:
+                        stopBy: neighbor
+                        kind: field_expression
+                        all:
+                          - has:
+                              stopBy: end
+                              kind: call_expression
+                              all:
+                                - has:
+                                    stopBy: neighbor
+                                    kind: field_expression
+                                    all:
+                                      - has:
+                                          stopBy: neighbor
+                                          kind: identifier
+                                          pattern: $C
+                                - has:
+                                    stopBy: neighbor
+                                    kind: arguments
+                          - has:
+                              stopBy: neighbor
+                              kind: field_identifier
+                    - has:
+                        stopBy: neighbor
+                        kind: arguments
+            - has:
+                stopBy: neighbor
+                kind: field_identifier
+                regex: "^password$"
+      - has:
+          stopBy: neighbor
+          kind: arguments
+          has:
+            stopBy: neighbor
+            kind: string_literal
+            not:
+             has:
+              stopBy: neighbor
+              kind: string_content
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows: 
+            stopBy: end
+            kind: let_declaration
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $C
+              - has:
+                  stopBy: neighbor
+                  kind: call_expression
+                  pattern: postgres::Config::new()
+
+  MATCH_PASSWORD_DIRECTLY:
+    kind: call_expression
+    all:
+      - has:
+          stopBy: neighbor
+          kind: field_expression
+          all:
+            - has:
+                stopBy: neighbor
+                kind: call_expression
+                all:
+                  - has:
+                      stopBy: neighbor
+                      kind: field_expression
+                      all:
+                        - has:
+                            stopBy: neighbor
+                            kind: call_expression
+                            all:
+                              - has:
+                                  stopBy: neighbor
+                                  kind: field_expression
+                                  has:
+                                    stopBy: neighbor
+                                    kind: call_expression
+                                    pattern: postgres::Config::new()
+                              - has:
+                                  stopBy: neighbor
+                                  kind: arguments
+                        - has:
+                            stopBy: neighbor
+                            kind: field_identifier
+                  - has:
+                      stopBy: neighbor
+                      kind: arguments
+            - has:
+                stopBy: neighbor
+                kind: field_identifier
+                regex: '^password$'
+      - has:
+          stopBy: end
+          kind: arguments
+          has:
+            stopBy: end
+            kind: string_literal
+            not:
+             has:
+              stopBy: neighbor
+              kind: string_content
+          
+  MATCH_PATTERN_PASSWORD_WITH_ITS_INSTANCE:
+    kind: call_expression
+    all:
+      - has:
+          stopBy: neighbor
+          kind: field_expression
+          all:
+            - has:
+                stopBy: neighbor
+                kind: call_expression
+                all:
+                  - has:
+                      stopBy: neighbor
+                      kind: field_expression
+                      all:
+                        - has:
+                            stopBy: neighbor
+                            kind: call_expression
+                            all:
+                              - has:
+                                  stopBy: neighbor
+                                  kind: field_expression
+                                  has:
+                                    stopBy: neighbor
+                                    kind: call_expression
+                                    pattern: postgres::Config::new()
+                              - has:
+                                  stopBy: neighbor
+                                  kind: arguments
+                        - has:
+                            stopBy: neighbor
+                            kind: field_identifier
+                  - has:
+                      stopBy: neighbor
+                      kind: arguments
+            - has:
+                stopBy: neighbor
+                kind: field_identifier
+                regex: '^password$'
+      - has:
+          stopBy: neighbor
+          kind: arguments
+          has:
+            stopBy: neighbor
+            kind: identifier
+            pattern: $E
+      - inside:
+          stopBy: end
+          kind: let_declaration
+          follows:
+            stopby: end
+            kind: expression_statement 
+            has:
+              stopBy: neighbor
+              kind: assignment_expression
+              all:
+                - has:
+                    stopBy: end
+                    kind: identifier
+                    pattern: $E
+                - has:
+                    stopBy: end
+                    kind: string_literal
+                    not:
+                     has:
+                      stopBy: end
+                      kind: string_content
+                      
+  MATCH_PATTERN_WITH_INSTANCE_&_PASSWORD_WITH_ITS_INSTANCE:
+    kind: call_expression
+    all:
+      - has:
+          stopBy: neighbor
+          kind: field_expression
+          all:
+            - has:
+                  stopBy: neighbor
+                  kind: call_expression
+                  all:
+                    - has:
+                        stopBy: neighbor
+                        kind: field_expression
+                        all:
+                          - has:
+                              stopBy: end
+                              kind: call_expression
+                              all:
+                                - has:
+                                    stopBy: neighbor
+                                    kind: field_expression
+                                    all:
+                                      - has:
+                                          stopBy: neighbor
+                                          kind: identifier
+                                          pattern: $C
+                                - has:
+                                    stopBy: neighbor
+                                    kind: arguments
+                          - has:
+                              stopBy: neighbor
+                              kind: field_identifier
+                    - has:
+                        stopBy: neighbor
+                        kind: arguments
+            - has:
+                stopBy: neighbor
+                kind: field_identifier
+                regex: "^password$"
+      - has:
+          stopBy: neighbor
+          kind: arguments
+          has:
+            stopBy: neighbor
+            kind: identifier
+            pattern: $Z
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows: 
+            stopBy: end
+            kind: let_declaration
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $C
+              - has:
+                  stopBy: neighbor
+                  kind: call_expression
+                  pattern: postgres::Config::new()
+      - inside:
+          stopBy: end
+          kind: block
+          has:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: neighbor
+              kind: assignment_expression
+              all:
+                - has:
+                   stopBy: neighbor
+                   kind: identifier
+                   pattern: $Z
+                - has:
+                    stopBy: neighbor
+                    kind: string_literal
+                    not:
+                      has:
+                       stopBy: neighbor
+                       kind: string_content
+
+rule:
+   kind: call_expression
+   any:
+    - matches: MATCH_PATTERN_WITH_INSTANCE
+    - matches: MATCH_PASSWORD_DIRECTLY
+    - matches: MATCH_PATTERN_PASSWORD_WITH_ITS_INSTANCE
+    - matches: MATCH_PATTERN_WITH_INSTANCE_&_PASSWORD_WITH_ITS_INSTANCE
+
+

--- a/rules/rust/security/reqwest-accept-invalid-rust.yml
+++ b/rules/rust/security/reqwest-accept-invalid-rust.yml
@@ -1,0 +1,23 @@
+id: reqwest-accept-invalid-rust
+language: rust
+severity: warning
+message: >-
+    Dangerously accepting invalid TLS
+note: >-
+  [CWE-295]: Improper Certificate
+  [REFERENCES]
+      - https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_hostnames
+      - https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_certs
+utils:
+  match_call_expression:
+    kind: call_expression
+    any:
+      - pattern: $CLIENT.danger_accept_invalid_hostnames(true)
+      - pattern: $CLIENT.danger_accept_invalid_certs(true)
+rule:
+  any:
+    - matches: match_call_expression
+constraints:
+  CLIENT:
+    regex: '^reqwest::Client::builder\(\)'
+

--- a/rules/rust/security/ssl-verify-none-rust.yml
+++ b/rules/rust/security/ssl-verify-none-rust.yml
@@ -32,6 +32,7 @@ rule:
                     stopBy: end
                     kind: scoped_identifier
                     regex: ^openssl::ssl$
+
     - pattern: $BUILDER.set_verify(ssl::SSL_VERIFY_NONE)
       inside:
         stopBy: end
@@ -53,6 +54,7 @@ rule:
                     stopBy: end
                     kind: scoped_identifier
                     regex: ^openssl::ssl$
+    
     - pattern: $BUILDER.set_verify(SSL_VERIFY_NONE)
       inside:
         stopBy: end
@@ -75,7 +77,7 @@ rule:
                     stopBy: end
                     kind: scoped_identifier
                     regex: ^openssl::ssl$
-    
+
     - pattern: $BUILDER.set_verify($ALIAS)
       inside:
         stopBy: end
@@ -99,6 +101,5 @@ rule:
                         kind: identifier
                         field: alias
                         pattern: $ALIAS
-    
-    - pattern: $BUILDER.set_verify(openssl::ssl::SSL_VERIFY_NONE);
 
+    - pattern: $BUILDER.set_verify(openssl::ssl::SSL_VERIFY_NONE)

--- a/rules/rust/security/ssl-verify-none-rust.yml
+++ b/rules/rust/security/ssl-verify-none-rust.yml
@@ -1,0 +1,87 @@
+id: ssl-verify-none-rust
+language: rust
+severity: warning
+message: >-
+  SSL verification disabled, this allows for MitM attacks
+note: >-
+  [CWE-295]: Improper Certificate Validation
+  [REFERENCES]
+    - https://docs.rs/openssl/latest/openssl/ssl/struct.SslContextBuilder.html#method.set_verify
+
+rule:
+  kind: call_expression
+  any:
+    - pattern: $BUILDER.set_verify(openssl::ssl::SSL_VERIFY_NONE)
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: use_declaration
+          any:
+            - pattern: use openssl;
+            - pattern: use openssl::ssl;
+            - pattern: use openssl::ssl::SSL_VERIFY_NONE;
+            - has:
+                stopBy: end
+                kind: use_list
+                has:
+                  stopBy: end
+                  kind: identifier
+                  pattern: SSL_VERIFY_NONE
+    - pattern: $BUILDER.set_verify(ssl::SSL_VERIFY_NONE)
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: use_declaration
+          any:
+            - pattern: use openssl::ssl;
+            - pattern: use openssl::ssl::SSL_VERIFY_NONE;
+            - has:
+                stopBy: end
+                kind: use_list
+                has:
+                  stopBy: end
+                  kind: identifier
+                  pattern: SSL_VERIFY_NONE
+    - pattern: $BUILDER.set_verify(SSL_VERIFY_NONE)
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: use_declaration
+          any:
+            - pattern: use openssl;
+            - pattern: use openssl::ssl;
+            - pattern: use openssl::ssl::SSL_VERIFY_NONE;
+            - has:
+                stopBy: end
+                kind: use_list
+                has:
+                  stopBy: end
+                  kind: identifier
+                  pattern: SSL_VERIFY_NONE
+    - pattern: $BUILDER.set_verify($ALIAS)
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: use_declaration
+          any:
+            - pattern: use openssl::ssl::SSL_VERIFY_NONE as $ALIAS;
+            - has:
+                stopBy: end
+                kind: use_list
+                has:
+                  stopBy: end
+                  kind: use_as_clause
+                  all:
+                    - has:
+                        kind: identifier
+                        field: path
+                        pattern: SSL_VERIFY_NONE
+                    - has:
+                        kind: identifier
+                        field: alias
+                        pattern: $ALIAS
+    - pattern: $BUILDER.set_verify(openssl::ssl::SSL_VERIFY_NONE);

--- a/rules/rust/security/ssl-verify-none-rust.yml
+++ b/rules/rust/security/ssl-verify-none-rust.yml
@@ -6,8 +6,7 @@ message: >-
 note: >-
   [CWE-295]: Improper Certificate Validation
   [REFERENCES]
-    - https://docs.rs/openssl/latest/openssl/ssl/struct.SslContextBuilder.html#method.set_verify
-
+    - https://docs.rs/openssl/latest/openssl/ssl/struct.SslContextBuilder.html#method.set_verify    
 rule:
   kind: call_expression
   any:
@@ -21,13 +20,18 @@ rule:
             - pattern: use openssl;
             - pattern: use openssl::ssl;
             - pattern: use openssl::ssl::SSL_VERIFY_NONE;
-            - has:
-                stopBy: end
-                kind: use_list
-                has:
-                  stopBy: end
-                  kind: identifier
-                  pattern: SSL_VERIFY_NONE
+            - all:
+                - has:
+                    stopBy: end
+                    kind: use_list
+                    has:
+                      stopBy: end
+                      kind: identifier
+                      regex: ^SSL_VERIFY_NONE$
+                - has:
+                    stopBy: end
+                    kind: scoped_identifier
+                    regex: ^openssl::ssl$
     - pattern: $BUILDER.set_verify(ssl::SSL_VERIFY_NONE)
       inside:
         stopBy: end
@@ -37,13 +41,18 @@ rule:
           any:
             - pattern: use openssl::ssl;
             - pattern: use openssl::ssl::SSL_VERIFY_NONE;
-            - has:
-                stopBy: end
-                kind: use_list
-                has:
-                  stopBy: end
-                  kind: identifier
-                  pattern: SSL_VERIFY_NONE
+            - all:
+                - has:
+                    stopBy: end
+                    kind: use_list
+                    has:
+                      stopBy: end
+                      kind: identifier
+                      regex: ^SSL_VERIFY_NONE$
+                - has:
+                    stopBy: end
+                    kind: scoped_identifier
+                    regex: ^openssl::ssl$
     - pattern: $BUILDER.set_verify(SSL_VERIFY_NONE)
       inside:
         stopBy: end
@@ -54,13 +63,19 @@ rule:
             - pattern: use openssl;
             - pattern: use openssl::ssl;
             - pattern: use openssl::ssl::SSL_VERIFY_NONE;
-            - has:
-                stopBy: end
-                kind: use_list
-                has:
-                  stopBy: end
-                  kind: identifier
-                  pattern: SSL_VERIFY_NONE
+            - all:
+                - has:
+                    stopBy: end
+                    kind: use_list
+                    has:
+                      stopBy: end
+                      kind: identifier
+                      regex: ^SSL_VERIFY_NONE$
+                - has:
+                    stopBy: end
+                    kind: scoped_identifier
+                    regex: ^openssl::ssl$
+    
     - pattern: $BUILDER.set_verify($ALIAS)
       inside:
         stopBy: end
@@ -84,4 +99,6 @@ rule:
                         kind: identifier
                         field: alias
                         pattern: $ALIAS
+    
     - pattern: $BUILDER.set_verify(openssl::ssl::SSL_VERIFY_NONE);
+

--- a/tests/__snapshots__/postgres-empty-password-rust-snapshot.yml
+++ b/tests/__snapshots__/postgres-empty-password-rust-snapshot.yml
@@ -1,0 +1,461 @@
+id: postgres-empty-password-rust
+snapshots:
+  ? |
+    async fn test2() -> Result<(), anyhow::Error> {
+    asa = "";
+    let (client, connection) = postgres::Config::new()
+    .host(shard_host_name.as_str())
+    .user("postgres")
+    .password(asa)
+    .dbname("ninja")
+    .keepalives_idle(std::time::Duration::from_secs(30))
+    .connect(NoTls)
+    .map_err(|e| {
+       error!(log, "failed to connect to {}: {}", &shard_host_name, e);
+       Error::new(ErrorKind::Other, e)
+    })?;
+    Ok(())
+    }
+  : labels:
+    - source: |-
+        postgres::Config::new()
+        .host(shard_host_name.as_str())
+        .user("postgres")
+        .password(asa)
+      style: primary
+      start: 85
+      end: 173
+    - source: postgres::Config::new()
+      style: secondary
+      start: 85
+      end: 108
+    - source: |-
+        postgres::Config::new()
+        .host
+      style: secondary
+      start: 85
+      end: 114
+    - source: (shard_host_name.as_str())
+      style: secondary
+      start: 114
+      end: 140
+    - source: |-
+        postgres::Config::new()
+        .host(shard_host_name.as_str())
+      style: secondary
+      start: 85
+      end: 140
+    - source: user
+      style: secondary
+      start: 142
+      end: 146
+    - source: |-
+        postgres::Config::new()
+        .host(shard_host_name.as_str())
+        .user
+      style: secondary
+      start: 85
+      end: 146
+    - source: ("postgres")
+      style: secondary
+      start: 146
+      end: 158
+    - source: |-
+        postgres::Config::new()
+        .host(shard_host_name.as_str())
+        .user("postgres")
+      style: secondary
+      start: 85
+      end: 158
+    - source: password
+      style: secondary
+      start: 160
+      end: 168
+    - source: |-
+        postgres::Config::new()
+        .host(shard_host_name.as_str())
+        .user("postgres")
+        .password
+      style: secondary
+      start: 85
+      end: 168
+    - source: asa
+      style: secondary
+      start: 169
+      end: 172
+    - source: (asa)
+      style: secondary
+      start: 168
+      end: 173
+    - source: asa
+      style: secondary
+      start: 48
+      end: 51
+    - source: '""'
+      style: secondary
+      start: 54
+      end: 56
+    - source: asa = ""
+      style: secondary
+      start: 48
+      end: 56
+    - source: asa = "";
+      style: secondary
+      start: 48
+      end: 57
+    - source: |-
+        let (client, connection) = postgres::Config::new()
+        .host(shard_host_name.as_str())
+        .user("postgres")
+        .password(asa)
+        .dbname("ninja")
+        .keepalives_idle(std::time::Duration::from_secs(30))
+        .connect(NoTls)
+        .map_err(|e| {
+           error!(log, "failed to connect to {}: {}", &shard_host_name, e);
+           Error::new(ErrorKind::Other, e)
+        })?;
+      style: secondary
+      start: 58
+      end: 382
+  ? |
+    fn test1() {
+    let mut config = postgres::Config::new();
+    as = "";
+    config
+     .host(std::env::var("HOST").expect("set HOST"))
+     .user(std::env::var("USER").expect("set USER"))
+     .password(as)
+     .port(std::env::var("PORT").expect("set PORT"));
+    let (client, connection) = config.connect(NoTls);
+    Ok(())
+    }
+  : labels:
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+         .password(as)
+      style: primary
+      start: 64
+      end: 183
+    - source: config
+      style: secondary
+      start: 64
+      end: 70
+    - source: |-
+        config
+         .host
+      style: secondary
+      start: 64
+      end: 77
+    - source: (std::env::var("HOST").expect("set HOST"))
+      style: secondary
+      start: 77
+      end: 119
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+      style: secondary
+      start: 64
+      end: 119
+    - source: user
+      style: secondary
+      start: 122
+      end: 126
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user
+      style: secondary
+      start: 64
+      end: 126
+    - source: (std::env::var("USER").expect("set USER"))
+      style: secondary
+      start: 126
+      end: 168
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+      style: secondary
+      start: 64
+      end: 168
+    - source: password
+      style: secondary
+      start: 171
+      end: 179
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+         .password
+      style: secondary
+      start: 64
+      end: 179
+    - source: as
+      style: secondary
+      start: 180
+      end: 182
+    - source: (as)
+      style: secondary
+      start: 179
+      end: 183
+    - source: config
+      style: secondary
+      start: 21
+      end: 27
+    - source: postgres::Config::new()
+      style: secondary
+      start: 30
+      end: 53
+    - source: let mut config = postgres::Config::new();
+      style: secondary
+      start: 13
+      end: 54
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+         .password(as)
+         .port(std::env::var("PORT").expect("set PORT"));
+      style: secondary
+      start: 64
+      end: 233
+    - source: as
+      style: secondary
+      start: 55
+      end: 57
+    - source: '""'
+      style: secondary
+      start: 60
+      end: 62
+    - source: as = ""
+      style: secondary
+      start: 55
+      end: 62
+    - source: as = "";
+      style: secondary
+      start: 55
+      end: 63
+    - source: |-
+        {
+        let mut config = postgres::Config::new();
+        as = "";
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+         .password(as)
+         .port(std::env::var("PORT").expect("set PORT"));
+        let (client, connection) = config.connect(NoTls);
+        Ok(())
+        }
+      style: secondary
+      start: 11
+      end: 292
+  ? |-
+    fn test1() {
+    let mut config = postgres::Config::new();
+    config
+     .host(std::env::var("HOST").expect("set HOST"))
+     .user(std::env::var("USER").expect("set USER"))
+     .password("")
+     .port(std::env::var("PORT").expect("set PORT"));
+    let (client, connection) = config.connect(NoTls);
+    Ok(())
+    }
+  : labels:
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+         .password("")
+      style: primary
+      start: 55
+      end: 174
+    - source: config
+      style: secondary
+      start: 55
+      end: 61
+    - source: |-
+        config
+         .host
+      style: secondary
+      start: 55
+      end: 68
+    - source: (std::env::var("HOST").expect("set HOST"))
+      style: secondary
+      start: 68
+      end: 110
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+      style: secondary
+      start: 55
+      end: 110
+    - source: user
+      style: secondary
+      start: 113
+      end: 117
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user
+      style: secondary
+      start: 55
+      end: 117
+    - source: (std::env::var("USER").expect("set USER"))
+      style: secondary
+      start: 117
+      end: 159
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+      style: secondary
+      start: 55
+      end: 159
+    - source: password
+      style: secondary
+      start: 162
+      end: 170
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+         .password
+      style: secondary
+      start: 55
+      end: 170
+    - source: '""'
+      style: secondary
+      start: 171
+      end: 173
+    - source: ("")
+      style: secondary
+      start: 170
+      end: 174
+    - source: config
+      style: secondary
+      start: 21
+      end: 27
+    - source: postgres::Config::new()
+      style: secondary
+      start: 30
+      end: 53
+    - source: let mut config = postgres::Config::new();
+      style: secondary
+      start: 13
+      end: 54
+    - source: |-
+        config
+         .host(std::env::var("HOST").expect("set HOST"))
+         .user(std::env::var("USER").expect("set USER"))
+         .password("")
+         .port(std::env::var("PORT").expect("set PORT"));
+      style: secondary
+      start: 55
+      end: 224
+  ? |
+    fn test1() {
+    let mut config = postgres::Config::new();
+    config
+    .host(std::env::var("HOST").expect("set HOST"))
+    .user(std::env::var("USER").expect("set USER"))
+    .password("")
+    .port(std::env::var("PORT").expect("set PORT"));
+    let (client, connection) = config.connect(NoTls);
+    Ok(())
+    }
+  : labels:
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user(std::env::var("USER").expect("set USER"))
+        .password("")
+      style: primary
+      start: 55
+      end: 171
+    - source: config
+      style: secondary
+      start: 55
+      end: 61
+    - source: |-
+        config
+        .host
+      style: secondary
+      start: 55
+      end: 67
+    - source: (std::env::var("HOST").expect("set HOST"))
+      style: secondary
+      start: 67
+      end: 109
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+      style: secondary
+      start: 55
+      end: 109
+    - source: user
+      style: secondary
+      start: 111
+      end: 115
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user
+      style: secondary
+      start: 55
+      end: 115
+    - source: (std::env::var("USER").expect("set USER"))
+      style: secondary
+      start: 115
+      end: 157
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user(std::env::var("USER").expect("set USER"))
+      style: secondary
+      start: 55
+      end: 157
+    - source: password
+      style: secondary
+      start: 159
+      end: 167
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user(std::env::var("USER").expect("set USER"))
+        .password
+      style: secondary
+      start: 55
+      end: 167
+    - source: '""'
+      style: secondary
+      start: 168
+      end: 170
+    - source: ("")
+      style: secondary
+      start: 167
+      end: 171
+    - source: config
+      style: secondary
+      start: 21
+      end: 27
+    - source: postgres::Config::new()
+      style: secondary
+      start: 30
+      end: 53
+    - source: let mut config = postgres::Config::new();
+      style: secondary
+      start: 13
+      end: 54
+    - source: |-
+        config
+        .host(std::env::var("HOST").expect("set HOST"))
+        .user(std::env::var("USER").expect("set USER"))
+        .password("")
+        .port(std::env::var("PORT").expect("set PORT"));
+      style: secondary
+      start: 55
+      end: 220

--- a/tests/__snapshots__/reqwest-accept-invalid-rust-snapshot.yml
+++ b/tests/__snapshots__/reqwest-accept-invalid-rust-snapshot.yml
@@ -1,0 +1,29 @@
+id: reqwest-accept-invalid-rust
+snapshots:
+  ? |
+    reqwest::Client::builder().danger_accept_invalid_certs(true)
+  : labels:
+    - source: reqwest::Client::builder().danger_accept_invalid_certs(true)
+      style: primary
+      start: 0
+      end: 60
+  ? |
+    reqwest::Client::builder().danger_accept_invalid_hostnames(true)
+  : labels:
+    - source: reqwest::Client::builder().danger_accept_invalid_hostnames(true)
+      style: primary
+      start: 0
+      end: 64
+  'reqwest::Client::builder().user_agent("USER AGENT").cookie_store(true).danger_accept_invalid_certs(true)      ':
+    labels:
+    - source: reqwest::Client::builder().user_agent("USER AGENT").cookie_store(true).danger_accept_invalid_certs(true)
+      style: primary
+      start: 0
+      end: 104
+  ? |
+    reqwest::Client::builder().user_agent("USER AGENT").cookie_store(true).danger_accept_invalid_hostnames(true)
+  : labels:
+    - source: reqwest::Client::builder().user_agent("USER AGENT").cookie_store(true).danger_accept_invalid_hostnames(true)
+      style: primary
+      start: 0
+      end: 108

--- a/tests/__snapshots__/ssl-verify-none-rust-snapshot.yml
+++ b/tests/__snapshots__/ssl-verify-none-rust-snapshot.yml
@@ -1,0 +1,80 @@
+id: ssl-verify-none-rust
+snapshots:
+  ? "use openssl::ssl::{\n  SslMethod, \n  SslConnectorBuilder, \n  SSL_VERIFY_NONE\n};\nconnector.builder_mut().set_verify(SSL_VERIFY_NONE);\n"
+  : labels:
+    - source: connector.builder_mut().set_verify(SSL_VERIFY_NONE)
+      style: primary
+      start: 79
+      end: 130
+    - source: SSL_VERIFY_NONE
+      style: secondary
+      start: 60
+      end: 75
+    - source: "{\n  SslMethod, \n  SslConnectorBuilder, \n  SSL_VERIFY_NONE\n}"
+      style: secondary
+      start: 18
+      end: 77
+    - source: "use openssl::ssl::{\n  SslMethod, \n  SslConnectorBuilder, \n  SSL_VERIFY_NONE\n};"
+      style: secondary
+      start: 0
+      end: 78
+    - source: "use openssl::ssl::{\n  SslMethod, \n  SslConnectorBuilder, \n  SSL_VERIFY_NONE\n};"
+      style: secondary
+      start: 0
+      end: 78
+  ? |
+    use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+    connector.builder_mut().set_verify(SSL_VERIFY_NONE);
+  : labels:
+    - source: connector.builder_mut().set_verify(SSL_VERIFY_NONE)
+      style: primary
+      start: 69
+      end: 120
+    - source: SSL_VERIFY_NONE
+      style: secondary
+      start: 51
+      end: 66
+    - source: '{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE}'
+      style: secondary
+      start: 18
+      end: 67
+    - source: use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+      style: secondary
+      start: 0
+      end: 68
+    - source: use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+      style: secondary
+      start: 0
+      end: 68
+  ? |
+    use openssl::ssl;
+    connector.builder_mut().set_verify(ssl::SSL_VERIFY_NONE);
+  : labels:
+    - source: connector.builder_mut().set_verify(ssl::SSL_VERIFY_NONE)
+      style: primary
+      start: 18
+      end: 74
+    - source: use openssl::ssl;
+      style: secondary
+      start: 0
+      end: 17
+    - source: use openssl::ssl;
+      style: secondary
+      start: 0
+      end: 17
+  ? |
+    use openssl;
+    connector.builder_mut().set_verify(openssl::ssl::SSL_VERIFY_NONE);
+  : labels:
+    - source: connector.builder_mut().set_verify(openssl::ssl::SSL_VERIFY_NONE)
+      style: primary
+      start: 13
+      end: 78
+    - source: use openssl;
+      style: secondary
+      start: 0
+      end: 12
+    - source: use openssl;
+      style: secondary
+      start: 0
+      end: 12

--- a/tests/rust/postgres-empty-password-rust-test.yml
+++ b/tests/rust/postgres-empty-password-rust-test.yml
@@ -1,0 +1,68 @@
+id: postgres-empty-password-rust
+valid:
+  - |
+     async fn okTest2() {
+     let (client, connection) = postgres::Config::new()
+     .host(shard_host_name.as_str())
+     .user("postgres")
+     .password("postgres")
+     .dbname("ninja")
+     .keepalives_idle(std::time::Duration::from_secs(30))
+     .connect(NoTls)
+     .map_err(|e| {
+     error!(log, "failed to connect to {}: {}", &shard_host_name, e);
+     Error::new(ErrorKind::Other, e)
+     })?;
+      Ok(())
+      }
+invalid:
+  - |
+     fn test1() {
+     let mut config = postgres::Config::new();
+     config
+     .host(std::env::var("HOST").expect("set HOST"))
+     .user(std::env::var("USER").expect("set USER"))
+     .password("")
+     .port(std::env::var("PORT").expect("set PORT"));
+     let (client, connection) = config.connect(NoTls);
+     Ok(())
+     }
+  - |
+     fn test1() {
+     let mut config = postgres::Config::new();
+     as = "";
+     config
+      .host(std::env::var("HOST").expect("set HOST"))
+      .user(std::env::var("USER").expect("set USER"))
+      .password(as)
+      .port(std::env::var("PORT").expect("set PORT"));
+     let (client, connection) = config.connect(NoTls);
+     Ok(())
+     }
+  - |
+     async fn test2() -> Result<(), anyhow::Error> {
+     asa = "";
+     let (client, connection) = postgres::Config::new()
+     .host(shard_host_name.as_str())
+     .user("postgres")
+     .password(asa)
+     .dbname("ninja")
+     .keepalives_idle(std::time::Duration::from_secs(30))
+     .connect(NoTls)
+     .map_err(|e| {
+        error!(log, "failed to connect to {}: {}", &shard_host_name, e);
+        Error::new(ErrorKind::Other, e)
+     })?;
+     Ok(())
+     }
+  - |
+     fn test1() {
+     let mut config = postgres::Config::new();
+     config
+      .host(std::env::var("HOST").expect("set HOST"))
+      .user(std::env::var("USER").expect("set USER"))
+      .password("")
+      .port(std::env::var("PORT").expect("set PORT"));
+     let (client, connection) = config.connect(NoTls);
+     Ok(())
+     }

--- a/tests/rust/reqwest-accept-invalid-rust-test.yml
+++ b/tests/rust/reqwest-accept-invalid-rust-test.yml
@@ -1,0 +1,13 @@
+id: reqwest-accept-invalid-rust
+valid:
+  - |
+    reqwest::Client::builder().user_agent("USER AGENT")
+invalid:
+  - |
+    reqwest::Client::builder().danger_accept_invalid_hostnames(true)
+  - |
+    reqwest::Client::builder().danger_accept_invalid_certs(true)
+  - |
+    reqwest::Client::builder().user_agent("USER AGENT").cookie_store(true).danger_accept_invalid_hostnames(true)
+  - |
+    reqwest::Client::builder().user_agent("USER AGENT").cookie_store(true).danger_accept_invalid_certs(true)      

--- a/tests/rust/ssl-verify-none-rust-test.yml
+++ b/tests/rust/ssl-verify-none-rust-test.yml
@@ -1,0 +1,22 @@
+id: ssl-verify-none-rust
+valid:
+  - |
+    use openssl::ssl::SSL_VERIFY_NONE;
+    connector.builder_mut().set_verify(SSL_VERIFY_PEER);
+invalid:
+  - |
+    use openssl;
+    connector.builder_mut().set_verify(openssl::ssl::SSL_VERIFY_NONE);
+  - |
+    use openssl::ssl;
+    connector.builder_mut().set_verify(ssl::SSL_VERIFY_NONE);
+  - |
+    use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+    connector.builder_mut().set_verify(SSL_VERIFY_NONE);
+  - |
+    use openssl::ssl::{
+      SslMethod, 
+      SslConnectorBuilder, 
+      SSL_VERIFY_NONE
+    };
+    connector.builder_mut().set_verify(SSL_VERIFY_NONE);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced security rules for Rust applications to detect empty PostgreSQL passwords, invalid TLS certificates in `reqwest`, and disabled SSL verification.
- **Bug Fixes**
	- Added warnings for improper authentication and certificate validation practices.
- **Tests**
	- Implemented new test cases for validating PostgreSQL connection configurations, `reqwest` client settings, and SSL verification practices, including handling of invalid credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->