### PR TITLE
Add security rules for weak encryption practices in Java and Kotlin

### DIFF
--- a/rules/java/security/des-is-deprecated-java.yml
+++ b/rules/java/security/des-is-deprecated-java.yml
@@ -11,6 +11,6 @@ note: >-
       - https://www.nist.gov/news-events/news/2005/06/nist-withdraws-outdated-data-encryption-standard
 rule:
   pattern: $CIPHER.getInstance($SAS)
-constraints:
+constraints: 
   SAS:
-    regex: "DES"
+    regex: ^".*/DES/.*"|"DES"|"DES/.*"$

--- a/rules/java/security/rsa-no-padding-java.yml
+++ b/rules/java/security/rsa-no-padding-java.yml
@@ -1,0 +1,14 @@
+id: rsa-no-padding-java
+severity: warning
+language: java
+message: >-
+  Using RSA without OAEP mode weakens the encryption.
+note: >-
+  [CWE-326] Inadequate Encryption Strength
+  [REFERENCES]
+      - https://rdist.root.org/2009/10/06/why-rsa-encryption-padding-is-critical/
+rule:
+  pattern: $YST.getInstance($MODE)
+constraints:
+  MODE:
+    regex: 'RSA/[Nn][Oo][Nn][Ee]/NoPadding'

--- a/rules/kotlin/security/des-is-deprecated-kotlin.yml
+++ b/rules/kotlin/security/des-is-deprecated-kotlin.yml
@@ -1,0 +1,16 @@
+id: des-is-deprecated-kotlin
+severity: warning
+language: kotlin
+message: >-
+      DES is considered deprecated. AES is the recommended cipher. Upgrade to
+      use AES. See https://www.nist.gov/news-events/news/2005/06/nist-withdraws-outdated-data-encryption-standard
+      for more information.
+note: >-
+  [CWE-326] Inadequate Encryption Strength.
+  [REFERENCES]
+      - https://www.nist.gov/news-events/news/2005/06/nist-withdraws-outdated-data-encryption-standard
+rule:
+  pattern: $CIPHER.getInstance($SAS)
+constraints: 
+  SAS:
+    regex: ^"DES/.*"|"DES"$

--- a/tests/__snapshots__/des-is-deprecated-kotlin-snapshot.yml
+++ b/tests/__snapshots__/des-is-deprecated-kotlin-snapshot.yml
@@ -1,0 +1,9 @@
+id: des-is-deprecated-kotlin
+snapshots:
+  ? |
+    Cipher.getInstance("DES/ECB/PKCS5Padding");
+  : labels:
+    - source: Cipher.getInstance("DES/ECB/PKCS5Padding")
+      style: primary
+      start: 0
+      end: 42

--- a/tests/__snapshots__/rsa-no-padding-java-snapshot.yml
+++ b/tests/__snapshots__/rsa-no-padding-java-snapshot.yml
@@ -1,0 +1,16 @@
+id: rsa-no-padding-java
+snapshots:
+  ? |
+    Cipher.getInstance("RSA/NONE/NoPadding");
+  : labels:
+    - source: Cipher.getInstance("RSA/NONE/NoPadding")
+      style: primary
+      start: 0
+      end: 40
+  ? |
+    Cipher.getInstance("RSA/None/NoPadding");
+  : labels:
+    - source: Cipher.getInstance("RSA/None/NoPadding")
+      style: primary
+      start: 0
+      end: 40

--- a/tests/java/rsa-no-padding-java-test.yml
+++ b/tests/java/rsa-no-padding-java-test.yml
@@ -1,0 +1,9 @@
+id: rsa-no-padding-java
+valid:
+  - |
+    Cipher.getInstance("RSA/ECB/OAEPWithMD5AndMGF1Padding");
+invalid:
+  - |
+    Cipher.getInstance("RSA/None/NoPadding");
+  - |
+    Cipher.getInstance("RSA/NONE/NoPadding");

--- a/tests/kotlin/des-is-deprecated-kotlin-test.yml
+++ b/tests/kotlin/des-is-deprecated-kotlin-test.yml
@@ -1,0 +1,7 @@
+id: des-is-deprecated-kotlin
+valid:
+  - |
+    Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
+invalid:
+  - |
+    Cipher.getInstance("DES/ECB/PKCS5Padding");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new rule to identify the use of RSA encryption without OAEP padding in Java, with a warning severity.
	- Added a rule to flag the use of deprecated DES encryption in Kotlin, recommending AES as the preferred cipher.

- **Bug Fixes**
	- Enhanced the detection logic for deprecated DES usage in Java to improve specificity.

- **Tests**
	- Implemented new test cases for validating RSA and DES cipher instances, ensuring correct handling of encryption standards.

- **Snapshots**
	- Added snapshots for RSA and DES cipher configurations to enhance test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->