### PR TITLE
Add security rules to detect hard-coded secrets in Java and Python

### DIFF
--- a/rules/java/security/system-setproperty-hardcoded-secret-java.yml
+++ b/rules/java/security/system-setproperty-hardcoded-secret-java.yml
@@ -21,15 +21,27 @@ utils:
     inside:
       stopBy: end
       kind: argument_list
+      has:
+        kind: string_literal
+        any:
+          - has:
+              kind: string_fragment
+              regex: "^javax.net.ssl.keyStorePassword$"
+          - has:
+              kind: string_fragment
+              regex: "^javax.net.ssl.trustStorePassword$"
       inside:
         stopBy: end
         kind: method_invocation
         all:
           - has:
               stopBy: end
+              field: object
               kind: identifier
+              regex: "^System$"
           - has:
               stopBy: end
+              field: name
               kind: identifier
               regex: "^setProperty$"
         inside:
@@ -37,4 +49,3 @@ utils:
 rule:
   any:
     - matches: match_string_literal
-

--- a/rules/java/security/system-setproperty-hardcoded-secret-java.yml
+++ b/rules/java/security/system-setproperty-hardcoded-secret-java.yml
@@ -16,6 +16,8 @@ utils:
   match_string_literal:
     kind: string_literal
     nthChild: 2
+    not:
+      regex: ^""$
     inside:
       stopBy: end
       kind: argument_list
@@ -24,12 +26,12 @@ utils:
         kind: method_invocation
         all:
           - has:
-             stopBy: end
-             kind: identifier
+              stopBy: end
+              kind: identifier
           - has:
-             stopBy: end
-             kind: identifier
-             regex: '^setProperty$'
+              stopBy: end
+              kind: identifier
+              regex: "^setProperty$"
         inside:
           kind: expression_statement
 rule:

--- a/rules/java/security/system-setproperty-hardcoded-secret-java.yml
+++ b/rules/java/security/system-setproperty-hardcoded-secret-java.yml
@@ -1,0 +1,38 @@
+id: system-setproperty-hardcoded-secret-java
+language: java
+severity: warning
+message: >-
+    A secret is hard-coded in the application. Secrets stored in source
+    code, such as credentials, identifiers, and other types of sensitive data,
+    can be leaked and used by internal or external malicious actors. Use
+    environment variables to securely provide credentials and other secrets or
+    retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798]: Use of Hard-coded Credentials
+  [OWASP A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+utils:
+  match_string_literal:
+    kind: string_literal
+    nthChild: 2
+    inside:
+      stopBy: end
+      kind: argument_list
+      inside:
+        stopBy: end
+        kind: method_invocation
+        all:
+          - has:
+             stopBy: end
+             kind: identifier
+          - has:
+             stopBy: end
+             kind: identifier
+             regex: '^setProperty$'
+        inside:
+          kind: expression_statement
+rule:
+  any:
+    - matches: match_string_literal
+

--- a/rules/python/security/python-cassandra-hardcoded-secret-python.yml
+++ b/rules/python/security/python-cassandra-hardcoded-secret-python.yml
@@ -1,0 +1,245 @@
+id: python-cassandra-hardcoded-secret-python
+language: python
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source code, such as credentials, identifiers, and other types of sensitive data, can be leaked and used by internal or external malicious actors. Use environment variables to securely provide credentials and other secrets or retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798]: Use of Hard-coded Credentials
+  [A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+rule:
+  any:
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            regex: ^PlainTextAuthProvider$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^password$
+                  - has:
+                      nthChild: 2
+                      kind: string
+                      all:
+                        - has:
+                            kind: string_start
+                            nthChild: 1
+                        - has:
+                            kind: string_content
+                            nthChild: 2
+                        - has:
+                            kind: string_end
+                            nthChild: 3
+        - kind: call
+          has:
+            kind: identifier
+            regex: ^PlainTextAuthProvider$
+            precedes:
+              kind: argument_list
+              has:
+                nthChild: 2
+                kind: string
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: string_start
+                  - has:
+                      kind: string_content
+                      nthChild: 2
+                  - has:
+                      kind: string_end
+                      nthChild: 3
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^cassandra.auth$
+            - has:
+                stopBy: end
+                kind: dotted_name
+                regex: ^PlainTextAuthProvider$
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            regex: ^SaslAuthProvider$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^password$
+                  - has:
+                      nthChild: 2
+                      kind: string
+                      all:
+                        - has:
+                            kind: string_start
+                            nthChild: 1
+                        - has:
+                            kind: string_content
+                            nthChild: 2
+                        - has:
+                            kind: string_end
+                            nthChild: 3
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^cassandra.auth$
+            - has:
+                stopBy: end
+                kind: dotted_name
+                regex: ^SaslAuthProvider$
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            pattern: $PLAIN_ALIAS
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^password$
+                  - has:
+                      nthChild: 2
+                      kind: string
+                      all:
+                        - has:
+                            kind: string_start
+                            nthChild: 1
+                        - has:
+                            kind: string_content
+                            nthChild: 2
+                        - has:
+                            kind: string_end
+                            nthChild: 3
+        - kind: call
+          has:
+            kind: identifier
+            pattern: $PLAIN_ALIAS
+            precedes:
+              kind: argument_list
+              has:
+                nthChild: 2
+                kind: string
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: string_start
+                  - has:
+                      kind: string_content
+                      nthChild: 2
+                  - has:
+                      kind: string_end
+                      nthChild: 3
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^cassandra.auth$
+            - has:
+                stopBy: end
+                kind: aliased_import
+                all:
+                  - has:
+                      kind: dotted_name
+                      nthChild: 1
+                      regex: ^PlainTextAuthProvider$
+                  - has:
+                      kind: identifier
+                      field: alias
+                      nthChild: 2
+                      pattern: $PLAIN_ALIAS
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            pattern: $SASL_ALIAS
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^password$
+                  - has:
+                      nthChild: 2
+                      kind: string
+                      all:
+                        - has:
+                            kind: string_start
+                            nthChild: 1
+                        - has:
+                            kind: string_content
+                            nthChild: 2
+                        - has:
+                            kind: string_end
+                            nthChild: 3
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^cassandra.auth$
+            - has:
+                stopBy: end
+                kind: aliased_import
+                all:
+                  - has:
+                      kind: dotted_name
+                      nthChild: 1
+                      regex: ^SaslAuthProvider$
+                  - has:
+                      kind: identifier
+                      field: alias
+                      nthChild: 2
+                      pattern: $SASL_ALIAS

--- a/rules/python/security/python-couchbase-hardcoded-secret-python.yml
+++ b/rules/python/security/python-couchbase-hardcoded-secret-python.yml
@@ -1,0 +1,90 @@
+id: python-couchbase-hardcoded-secret-python
+language: python
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source code, such as credentials, identifiers, and other types of sensitive data, can be leaked and used by internal or external malicious actors. Use environment variables to securely provide credentials and other secrets or retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798]: Use of Hard-coded Credentials
+  [A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+rule:
+  any:
+    - kind: call
+      has:
+        kind: identifier
+        regex: ^PasswordAuthenticator$
+        precedes:
+          kind: argument_list
+          has:
+            nthChild: 2
+            kind: string
+            all:
+              - has:
+                  nthChild: 1
+                  kind: string_start
+              - has:
+                  kind: string_content
+                  nthChild: 2
+              - has:
+                  kind: string_end
+                  nthChild: 3
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^couchbase_core.cluster$
+            - has:
+                stopBy: end
+                kind: dotted_name
+                regex: ^PasswordAuthenticator$
+    - kind: call
+      has:
+        kind: identifier
+        pattern: $ALIAS
+        precedes:
+          kind: argument_list
+          has:
+            nthChild: 2
+            kind: string
+            all:
+              - has:
+                  nthChild: 1
+                  kind: string_start
+              - has:
+                  kind: string_content
+                  nthChild: 2
+              - has:
+                  kind: string_end
+                  nthChild: 3
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^couchbase_core.cluster$
+            - has:
+                stopBy: end
+                kind: aliased_import
+                all:
+                  - has:
+                      kind: dotted_name
+                      nthChild: 1
+                      regex: ^PasswordAuthenticator$
+                  - has:
+                      kind: identifier
+                      field: alias
+                      nthChild: 2
+                      pattern: $ALIAS

--- a/tests/__snapshots__/python-cassandra-hardcoded-secret-python-snapshot.yml
+++ b/tests/__snapshots__/python-cassandra-hardcoded-secret-python-snapshot.yml
@@ -1,0 +1,106 @@
+id: python-cassandra-hardcoded-secret-python
+snapshots:
+  ? |
+    from cassandra.auth import PlainTextAuthProvider
+    auth_provider = PlainTextAuthProvider('user', 'pass')
+  : labels:
+    - source: PlainTextAuthProvider('user', 'pass')
+      style: primary
+      start: 65
+      end: 102
+    - source: ''''
+      style: secondary
+      start: 95
+      end: 96
+    - source: pass
+      style: secondary
+      start: 96
+      end: 100
+    - source: ''''
+      style: secondary
+      start: 100
+      end: 101
+    - source: '''pass'''
+      style: secondary
+      start: 95
+      end: 101
+    - source: ('user', 'pass')
+      style: secondary
+      start: 86
+      end: 102
+    - source: PlainTextAuthProvider
+      style: secondary
+      start: 65
+      end: 86
+    - source: cassandra.auth
+      style: secondary
+      start: 5
+      end: 19
+    - source: PlainTextAuthProvider
+      style: secondary
+      start: 27
+      end: 48
+    - source: from cassandra.auth import PlainTextAuthProvider
+      style: secondary
+      start: 0
+      end: 48
+    - source: from cassandra.auth import PlainTextAuthProvider
+      style: secondary
+      start: 0
+      end: 48
+  ? |
+    from cassandra.auth import PlainTextAuthProvider
+    auth_provider = PlainTextAuthProvider(username='user', password='pass')
+  : labels:
+    - source: PlainTextAuthProvider(username='user', password='pass')
+      style: primary
+      start: 65
+      end: 120
+    - source: password
+      style: secondary
+      start: 104
+      end: 112
+    - source: ''''
+      style: secondary
+      start: 113
+      end: 114
+    - source: pass
+      style: secondary
+      start: 114
+      end: 118
+    - source: ''''
+      style: secondary
+      start: 118
+      end: 119
+    - source: '''pass'''
+      style: secondary
+      start: 113
+      end: 119
+    - source: password='pass'
+      style: secondary
+      start: 104
+      end: 119
+    - source: (username='user', password='pass')
+      style: secondary
+      start: 86
+      end: 120
+    - source: PlainTextAuthProvider
+      style: secondary
+      start: 65
+      end: 86
+    - source: cassandra.auth
+      style: secondary
+      start: 5
+      end: 19
+    - source: PlainTextAuthProvider
+      style: secondary
+      start: 27
+      end: 48
+    - source: from cassandra.auth import PlainTextAuthProvider
+      style: secondary
+      start: 0
+      end: 48
+    - source: from cassandra.auth import PlainTextAuthProvider
+      style: secondary
+      start: 0
+      end: 48

--- a/tests/__snapshots__/python-couchbase-hardcoded-secret-python-snapshot.yml
+++ b/tests/__snapshots__/python-couchbase-hardcoded-secret-python-snapshot.yml
@@ -1,0 +1,106 @@
+id: python-couchbase-hardcoded-secret-python
+snapshots:
+  ? |
+    from couchbase_core.cluster import PasswordAuthenticator
+    cluster = Cluster('couchbase://localhost', ClusterOptions(PasswordAuthenticator('username', 'password')))
+  : labels:
+    - source: PasswordAuthenticator('username', 'password')
+      style: primary
+      start: 115
+      end: 160
+    - source: couchbase_core.cluster
+      style: secondary
+      start: 5
+      end: 27
+    - source: PasswordAuthenticator
+      style: secondary
+      start: 35
+      end: 56
+    - source: from couchbase_core.cluster import PasswordAuthenticator
+      style: secondary
+      start: 0
+      end: 56
+    - source: from couchbase_core.cluster import PasswordAuthenticator
+      style: secondary
+      start: 0
+      end: 56
+    - source: ''''
+      style: secondary
+      start: 149
+      end: 150
+    - source: password
+      style: secondary
+      start: 150
+      end: 158
+    - source: ''''
+      style: secondary
+      start: 158
+      end: 159
+    - source: '''password'''
+      style: secondary
+      start: 149
+      end: 159
+    - source: ('username', 'password')
+      style: secondary
+      start: 136
+      end: 160
+    - source: PasswordAuthenticator
+      style: secondary
+      start: 115
+      end: 136
+  ? |
+    from couchbase_core.cluster import PasswordAuthenticator as abc
+    cluster = Cluster('couchbase://localhost', ClusterOptions(abc('username', 'password')))
+  : labels:
+    - source: abc('username', 'password')
+      style: primary
+      start: 122
+      end: 149
+    - source: couchbase_core.cluster
+      style: secondary
+      start: 5
+      end: 27
+    - source: PasswordAuthenticator
+      style: secondary
+      start: 35
+      end: 56
+    - source: abc
+      style: secondary
+      start: 60
+      end: 63
+    - source: PasswordAuthenticator as abc
+      style: secondary
+      start: 35
+      end: 63
+    - source: from couchbase_core.cluster import PasswordAuthenticator as abc
+      style: secondary
+      start: 0
+      end: 63
+    - source: from couchbase_core.cluster import PasswordAuthenticator as abc
+      style: secondary
+      start: 0
+      end: 63
+    - source: ''''
+      style: secondary
+      start: 138
+      end: 139
+    - source: password
+      style: secondary
+      start: 139
+      end: 147
+    - source: ''''
+      style: secondary
+      start: 147
+      end: 148
+    - source: '''password'''
+      style: secondary
+      start: 138
+      end: 148
+    - source: ('username', 'password')
+      style: secondary
+      start: 125
+      end: 149
+    - source: abc
+      style: secondary
+      start: 122
+      end: 125

--- a/tests/__snapshots__/system-setproperty-hardcoded-secret-java-snapshot.yml
+++ b/tests/__snapshots__/system-setproperty-hardcoded-secret-java-snapshot.yml
@@ -23,6 +23,14 @@ snapshots:
       style: secondary
       start: 0
       end: 64
+    - source: javax.net.ssl.keyStorePassword
+      style: secondary
+      start: 20
+      end: 50
+    - source: '"javax.net.ssl.keyStorePassword"'
+      style: secondary
+      start: 19
+      end: 51
     - source: ("javax.net.ssl.keyStorePassword", "password")
       style: secondary
       start: 18
@@ -50,6 +58,14 @@ snapshots:
       style: secondary
       start: 0
       end: 66
+    - source: javax.net.ssl.trustStorePassword
+      style: secondary
+      start: 20
+      end: 52
+    - source: '"javax.net.ssl.trustStorePassword"'
+      style: secondary
+      start: 19
+      end: 53
     - source: ("javax.net.ssl.trustStorePassword", "password")
       style: secondary
       start: 18

--- a/tests/__snapshots__/system-setproperty-hardcoded-secret-java-snapshot.yml
+++ b/tests/__snapshots__/system-setproperty-hardcoded-secret-java-snapshot.yml
@@ -1,0 +1,56 @@
+id: system-setproperty-hardcoded-secret-java
+snapshots:
+  ? |
+    System.setProperty("javax.net.ssl.keyStorePassword", "password");
+  : labels:
+    - source: '"password"'
+      style: primary
+      start: 53
+      end: 63
+    - source: System
+      style: secondary
+      start: 0
+      end: 6
+    - source: setProperty
+      style: secondary
+      start: 7
+      end: 18
+    - source: System.setProperty("javax.net.ssl.keyStorePassword", "password");
+      style: secondary
+      start: 0
+      end: 65
+    - source: System.setProperty("javax.net.ssl.keyStorePassword", "password")
+      style: secondary
+      start: 0
+      end: 64
+    - source: ("javax.net.ssl.keyStorePassword", "password")
+      style: secondary
+      start: 18
+      end: 64
+  ? |
+    System.setProperty("javax.net.ssl.trustStorePassword", "password");
+  : labels:
+    - source: '"password"'
+      style: primary
+      start: 55
+      end: 65
+    - source: System
+      style: secondary
+      start: 0
+      end: 6
+    - source: setProperty
+      style: secondary
+      start: 7
+      end: 18
+    - source: System.setProperty("javax.net.ssl.trustStorePassword", "password");
+      style: secondary
+      start: 0
+      end: 67
+    - source: System.setProperty("javax.net.ssl.trustStorePassword", "password")
+      style: secondary
+      start: 0
+      end: 66
+    - source: ("javax.net.ssl.trustStorePassword", "password")
+      style: secondary
+      start: 18
+      end: 66

--- a/tests/java/system-setproperty-hardcoded-secret-java-test.yml
+++ b/tests/java/system-setproperty-hardcoded-secret-java-test.yml
@@ -1,0 +1,10 @@
+id: system-setproperty-hardcoded-secret-java
+valid:
+  - |
+    System.setProperty("javax.net.ssl.trustStorePassword", config);
+    System.setProperty("javax.net.ssl.keyStorePassword", config);
+invalid:
+  - |
+    System.setProperty("javax.net.ssl.keyStorePassword", "password");
+  - |
+    System.setProperty("javax.net.ssl.trustStorePassword", "password");

--- a/tests/python/python-cassandra-hardcoded-secret-python-test.yml
+++ b/tests/python/python-cassandra-hardcoded-secret-python-test.yml
@@ -1,0 +1,12 @@
+id: python-cassandra-hardcoded-secret-python
+valid:
+  - |
+    from cassandra.auth import PlainTextAuthProvider
+    auth_provider = PlainTextAuthProvider('user', '')
+invalid:
+  - |
+    from cassandra.auth import PlainTextAuthProvider
+    auth_provider = PlainTextAuthProvider('user', 'pass')
+  - |
+    from cassandra.auth import PlainTextAuthProvider
+    auth_provider = PlainTextAuthProvider(username='user', password='pass')

--- a/tests/python/python-couchbase-hardcoded-secret-python-test.yml
+++ b/tests/python/python-couchbase-hardcoded-secret-python-test.yml
@@ -1,0 +1,12 @@
+id: python-couchbase-hardcoded-secret-python
+valid:
+  - |
+    from couchbase_core.cluster import PasswordAuthenticator
+    cluster = Cluster('couchbase://localhost', ClusterOptions(PasswordAuthenticator('username', get_pass())))
+invalid:
+  - |
+    from couchbase_core.cluster import PasswordAuthenticator
+    cluster = Cluster('couchbase://localhost', ClusterOptions(PasswordAuthenticator('username', 'password')))
+  - |
+    from couchbase_core.cluster import PasswordAuthenticator as abc
+    cluster = Cluster('couchbase://localhost', ClusterOptions(abc('username', 'password')))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced security rules for detecting hard-coded secrets in Java and Python applications, advising against storing sensitive data directly in the source code.
	- New rules added for Java (`system-setproperty-hardcoded-secret-java`) and Python (`python-cassandra-hardcoded-secret-python`, `python-couchbase-hardcoded-secret-python`).

- **Tests**
	- Added comprehensive test cases and snapshots to validate the implementation of security rules across Java and Python, ensuring adherence to secure coding practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->