### PR TITLE
Add Security Rules for Hard-Coded Secrets in Python Applications

### DIFF
--- a/rules/python/security/python-ldap3-hardcoded-secret-python.yml
+++ b/rules/python/security/python-ldap3-hardcoded-secret-python.yml
@@ -1,0 +1,25 @@
+id: python-ldap3-hardcoded-secret-python
+language: python
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source code, such as credentials, identifiers, and other types of sensitive data, can be leaked and used by internal or external malicious actors. Use environment variables to securely provide credentials and other secrets or retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798]: Use of Hard-coded Credentials
+  [A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+    - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+rule:
+  pattern: ldap3.Connection(password=$STR)
+constraints:
+  STR:
+    kind: string
+    all:
+      - has:
+          nthChild: 1
+          kind: string_start
+      - has:
+          nthChild: 2
+          kind: string_content
+      - has:
+          nthChild: 3
+          kind: string_end

--- a/rules/python/security/python-mariadb-empty-password-python.yml
+++ b/rules/python/security/python-mariadb-empty-password-python.yml
@@ -1,0 +1,86 @@
+id: python-mariadb-empty-password-python
+language: python
+severity: warning
+message: >-
+  The application creates a database connection with an empty password. This can lead to unauthorized access by either an internal or external malicious actor. To prevent this vulnerability, enforce authentication when connecting to a database by using environment variables to securely provide credentials or retrieving them from a secure vault or HSM (Hardware Security Module).
+note: >-
+  [CWE-287]: Improper Authentication
+  [A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+    - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+rule:
+  any:
+    - kind: call
+      has:
+        nthChild: 1
+        kind: attribute
+        regex: ^mariadb.connect$
+        precedes:
+          kind: argument_list
+          has:
+            kind: keyword_argument
+            has:
+              kind: identifier
+              regex: ^(password|passwd)$
+              precedes:
+                stopBy: end
+                kind: string
+                all:
+                  - has:
+                      kind: string_start
+                      nthChild: 1
+                  - has:
+                      kind: string_end
+                      nthChild: 2
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_statement
+          has:
+            kind: dotted_name
+            nthChild: 1
+            regex: ^mariadb$
+    - kind: call
+      has:
+        nthChild: 1
+        kind: attribute
+        all:
+          - has:
+              nthChild: 1
+              pattern: $ALAIS
+          - has:
+              nthChild: 2
+              regex: ^connect$
+        precedes:
+          kind: argument_list
+          has:
+            kind: keyword_argument
+            has:
+              kind: identifier
+              regex: ^(password|passwd)$
+              precedes:
+                stopBy: end
+                kind: string
+                all:
+                  - has:
+                      kind: string_start
+                      nthChild: 1
+                  - has:
+                      kind: string_end
+                      nthChild: 2
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_statement
+          has:
+            kind: aliased_import
+            all:
+              - has:
+                  kind: dotted_name
+                  regex: ^mariadb$
+              - has:
+                  kind: identifier
+                  pattern: $ALAIS

--- a/rules/python/security/python-mariadb-hardcoded-secret-python.yml
+++ b/rules/python/security/python-mariadb-hardcoded-secret-python.yml
@@ -1,0 +1,94 @@
+id: python-mariadb-hardcoded-secret-python
+language: python
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source code, such as credentials, identifiers, and other types of sensitive data, can be leaked and used by internal or external malicious actors. Use environment variables to securely provide credentials and other secrets or retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-287]: Improper Authentication
+  [A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+    - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+rule:
+  any:
+    - kind: call
+      has:
+        nthChild: 1
+        kind: attribute
+        regex: ^mariadb.connect$
+        precedes:
+          kind: argument_list
+          has:
+            kind: keyword_argument
+            has:
+              kind: identifier
+              regex: ^(password|passwd)$
+              precedes:
+                stopBy: end
+                kind: string
+                all:
+                  - has:
+                      kind: string_start
+                      nthChild: 1
+                  - has:
+                      kind: string_content
+                      nthChild: 2
+                  - has:
+                      kind: string_end
+                      nthChild: 3
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_statement
+          has:
+            kind: dotted_name
+            nthChild: 1
+            regex: ^mariadb$
+    - kind: call
+      has:
+        nthChild: 1
+        kind: attribute
+        all:
+          - has:
+              nthChild: 1
+              pattern: $ALAIS
+          - has:
+              nthChild: 2
+              regex: ^connect$
+        precedes:
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+              - has:
+                  kind: identifier
+                  regex: ^(password|passwd)$
+                  nthChild: 1
+              - has:
+                  kind: string
+                  all:
+                    - has:
+                        kind: string_start
+                        nthChild: 1
+                    - has:
+                        kind: string_content
+                        nthChild: 2
+                    - has:
+                        kind: string_end
+                        nthChild: 3
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_statement
+          has:
+            kind: aliased_import
+            all:
+              - has:
+                  kind: dotted_name
+                  regex: ^mariadb$
+              - has:
+                  kind: identifier
+                  pattern: $ALAIS

--- a/tests/__snapshots__/python-ldap3-hardcoded-secret-python-snapshot.yml
+++ b/tests/__snapshots__/python-ldap3-hardcoded-secret-python-snapshot.yml
@@ -1,0 +1,21 @@
+id: python-ldap3-hardcoded-secret-python
+snapshots:
+  ? |
+    ldap3.Connection(password="notreal")
+  : labels:
+    - source: ldap3.Connection(password="notreal")
+      style: primary
+      start: 0
+      end: 36
+    - source: '"'
+      style: secondary
+      start: 26
+      end: 27
+    - source: notreal
+      style: secondary
+      start: 27
+      end: 34
+    - source: '"'
+      style: secondary
+      start: 34
+      end: 35

--- a/tests/__snapshots__/python-mariadb-empty-password-python-snapshot.yml
+++ b/tests/__snapshots__/python-mariadb-empty-password-python-snapshot.yml
@@ -1,0 +1,68 @@
+id: python-mariadb-empty-password-python
+snapshots:
+  ? |
+    import mariadb as mrdbl123
+    {
+      mrdbl123.connect(host="this.is.my.host",user="root",passwd="",database="aaa")
+    }
+  : labels:
+    - source: mrdbl123.connect(host="this.is.my.host",user="root",passwd="",database="aaa")
+      style: primary
+      start: 31
+      end: 108
+    - source: mariadb
+      style: secondary
+      start: 7
+      end: 14
+    - source: mrdbl123
+      style: secondary
+      start: 18
+      end: 26
+    - source: mariadb as mrdbl123
+      style: secondary
+      start: 7
+      end: 26
+    - source: import mariadb as mrdbl123
+      style: secondary
+      start: 0
+      end: 26
+    - source: import mariadb as mrdbl123
+      style: secondary
+      start: 0
+      end: 26
+    - source: mrdbl123
+      style: secondary
+      start: 31
+      end: 39
+    - source: connect
+      style: secondary
+      start: 40
+      end: 47
+    - source: '"'
+      style: secondary
+      start: 90
+      end: 91
+    - source: '"'
+      style: secondary
+      start: 91
+      end: 92
+    - source: '""'
+      style: secondary
+      start: 90
+      end: 92
+    - source: passwd
+      style: secondary
+      start: 83
+      end: 89
+    - source: passwd=""
+      style: secondary
+      start: 83
+      end: 92
+    - source: (host="this.is.my.host",user="root",passwd="",database="aaa")
+      style: secondary
+      start: 47
+      end: 108
+    - source: mrdbl123.connect
+      style: secondary
+      start: 31
+      end: 47

--- a/tests/python/python-ldap3-hardcoded-secret-python-test.yml
+++ b/tests/python/python-ldap3-hardcoded-secret-python-test.yml
@@ -1,0 +1,7 @@
+id: python-ldap3-hardcoded-secret-python
+valid:
+  - |
+    ldap3.Connection(password=os.env['SECRET'])
+invalid:
+  - |
+    ldap3.Connection(password="notreal")

--- a/tests/python/python-mariadb-empty-password-python-test.yml
+++ b/tests/python/python-mariadb-empty-password-python-test.yml
@@ -1,0 +1,13 @@
+id: python-mariadb-empty-password-python
+valid:
+  - |
+    import mariadb as mrdbl123
+    {
+      mrdbl123.connect(host="this.is.my.host",user="root",passwd="password",database="aaa")
+    }
+invalid:
+  - |
+    import mariadb as mrdbl123
+    {
+      mrdbl123.connect(host="this.is.my.host",user="root",passwd="",database="aaa")
+    }

--- a/tests/python/python-mariadb-hardcoded-secret-python-test.yml
+++ b/tests/python/python-mariadb-hardcoded-secret-python-test.yml
@@ -1,0 +1,13 @@
+id: python-mariadb-hardcoded-secret-python
+valid:
+  - |
+    import mariadb as mrdbl123
+    {
+      mrdbl123.connect(host="this.is.my.host",user="root",passwd="",database="aaa")
+    }
+invalid:
+  - |
+    import mariadb as mrdbl123
+    {
+      mrdbl123.connect(host="this.is.my.host",user="root",passwd="password",database="aaa")
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new security rules to identify hard-coded secrets and empty passwords in Python applications using `ldap3` and `MariaDB`.
  
- **Tests**
  - Added validation tests to ensure secure practices for managing secrets and handling database connections without hard-coded credentials or empty passwords.

These enhancements aim to improve security and promote best practices in Python development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->