### PR TITLE
Add new static analysis rules for C/C++ with test configurations

### DIFF
--- a/rules/c/security/sizeof-this-c.yml
+++ b/rules/c/security/sizeof-this-c.yml
@@ -1,0 +1,30 @@
+id: sizeof-this-c
+language: c
+severity: warning
+message: >-
+    Do not use `sizeof(this)` to get the number of bytes of the object in
+    memory. It returns the size of the pointer, not the size of the object.
+note: >-
+  [CWE-467]: Use of sizeof() on a Pointer Type
+  [REFERENCES]
+      - https://wiki.sei.cmu.edu/confluence/display/c/ARR01-C.+Do+not+apply+the+sizeof+operator+to+a+pointer+when+taking+the+size+of+an+array
+utils:
+      match_sizeof_this:
+            kind: function_declarator
+            all:
+                  - has:
+                          stopBy: end
+                          kind: field_identifier
+                          regex: '^sizeof$'
+                  - has:
+                          has:
+                                stopBy: end
+                                kind: parameter_declaration
+                                has:
+                                      stopBy: end
+                                      kind: type_identifier
+                                      regex: '^this$'
+rule:
+      any:
+      - matches: match_sizeof_this
+

--- a/rules/c/security/small-key-size-c.yml
+++ b/rules/c/security/small-key-size-c.yml
@@ -1,0 +1,59 @@
+id: small-key-size-c
+language: c
+severity: warning
+message: >-
+    $KEY_FUNCTION` is using a key size of only $KEY_BITS bits. This is
+    less than the recommended key size of 2048 bits.
+note: >-
+  [CWE-326]: Inadequate Encryption Strength
+  [OWASP A02:2021]: Cryptographic Failures
+  [OWASP A03:2017]: Sensitive Data Exposure
+  [REFERENCES]
+       https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf
+       https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+utils:
+  Match_pattern_with_prefix_statement:
+    kind: expression_statement
+    all:
+      - has:
+         stopBy: end
+         kind: call_expression
+         all:
+         - has: 
+            stopBy: end
+            kind: identifier
+           pattern: $AST
+         - has:
+            stopBy: end
+            kind: argument_list
+            has:
+             stopby: end
+             kind: identifier
+             pattern: $Q
+      - follows:
+          stopBy: end
+          kind: declaration
+          has:
+            stopBy: end
+            kind: init_declarator
+            all:
+              - has:
+                 stopBy: end
+                 kind: identifier
+                 pattern: $Q
+              - has:
+                 stopBy: end
+                 kind: number_literal
+                 pattern: $AASS
+
+          
+rule:
+  kind: expression_statement
+  matches: Match_pattern_with_prefix_statement
+constraints:
+  AST:
+   regex: (DH_generate_parameters_ex|DSA_generate_parameters_ex|EVP_PKEY_CTX_set_dh_paramgen_prime_len|EVP_PKEY_CTX_set_dsa_paramgen_bits|EVP_PKEY_CTX_set_rsa_keygen_bits|RSA_generate_key_ex|RSA_generate_key_fips)
+  AASS:
+    regex: '^(-?(0|[1-9][0-9]?|[1-9][0-9]{2}|1[0-9]{3}|20[0-3][0-9]|204[0-7])(\.[0-9]+)?|0|-[1-9][0-9]*|-[1-9][0-9]{2,}|-1[0-9]{3}|-20[0-3][0-9]|-204[0-7])$'
+
+

--- a/rules/c/security/std-return-data-c.yml
+++ b/rules/c/security/std-return-data-c.yml
@@ -1,0 +1,114 @@
+id: std-return-data-c
+language: c
+severity: warning
+message: >-
+    $FUNC` returns a pointer to the memory owned by `$VAR`. This pointer
+    is invalid after `$VAR` goes out of scope, which can trigger a use after
+    free.
+note: >-
+  [CWE-416: Use After Free.
+  [REFERENCES]
+      - https://wiki.sei.cmu.edu/confluence/display/c/DCL30-C.+Declare+objects+with+appropriate+storage+durations
+utils:
+  MATCH_RETURN_STATEMENT_WITH_STD:
+    kind: return_statement
+    all:
+      - has:
+         stopBy: end
+         kind: call_expression
+         has:
+          stopBy: end
+          kind: field_expression
+          has:
+           stopBy: end
+           kind: identifier
+           pattern: $R
+      - follows:
+          stopBy: end
+          kind: labeled_statement
+          all:
+            - has:
+                stopBy: end
+                kind: statement_identifier
+                regex: ^std
+            - has:
+                stopBy: end
+                kind: expression_statement
+                has: 
+                  stopBy: end
+                  kind: binary_expression
+                  all:
+                    - has:
+                       stopBy: end
+                       kind: binary_expression
+                       all:
+                        - has: 
+                           stopBy: end
+                           kind: identifier
+                           regex: (vector|array|deque|forward_list|list|map|multimap|multiset|set|unordered_map|unordered_multimap|unordered_multiset|unordered_set)
+                        - has:
+                           stopBy: end
+                           kind: identifier
+                    - has:
+                        stopBy: end
+                        kind: identifier
+                        pattern: $R
+                        inside:
+                          stopBy: end
+                          kind: function_definition
+                          has:
+                            stopBy: end
+                            kind: primitive_type
+
+  MATCH_RETURN_STATEMENT_WITHOUT_STD:
+    kind: return_statement
+    all:
+      - has:
+         stopBy: end
+         kind: call_expression
+         has:
+          stopBy: end
+          kind: field_expression
+          has:
+           stopBy: end
+           kind: identifier
+           pattern: $R
+      - follows:
+                stopBy: end
+                kind: expression_statement
+                has: 
+                  stopBy: end
+                  kind: binary_expression
+                  all:
+                    - has:
+                       stopBy: end
+                       kind: binary_expression
+                       all:
+                        - has: 
+                           stopBy: end
+                           kind: identifier
+                           regex: (vector|array|deque|forward_list|list|map|multimap|multiset|set|unordered_map|unordered_multimap|unordered_multiset|unordered_set)
+                        - has:
+                           stopBy: end
+                           kind: identifier
+                    - has:
+                        stopBy: end
+                        kind: identifier
+                        pattern: $R   
+                        inside:
+                          stopBy: end
+                          kind: function_definition
+                          has:
+                            stopBy: end
+                            kind: primitive_type
+                                           
+rule:
+  kind: return_statement
+  any:
+    - matches: MATCH_RETURN_STATEMENT_WITH_STD
+    - matches: MATCH_RETURN_STATEMENT_WITHOUT_STD
+ 
+
+       
+
+

--- a/tests/__snapshots__/sizeof-this-c-snapshot.yml
+++ b/tests/__snapshots__/sizeof-this-c-snapshot.yml
@@ -1,0 +1,30 @@
+id: sizeof-this-c
+snapshots:
+  ? |
+    struct Foo {
+    uint64_t a;
+    uint8_t b;
+    size_t get_size() const {
+    return sizeof(this);
+    }
+  : labels:
+    - source: sizeof(this)
+      style: primary
+      start: 69
+      end: 81
+    - source: sizeof
+      style: secondary
+      start: 69
+      end: 75
+    - source: this
+      style: secondary
+      start: 76
+      end: 80
+    - source: this
+      style: secondary
+      start: 76
+      end: 80
+    - source: this
+      style: secondary
+      start: 76
+      end: 80

--- a/tests/__snapshots__/small-key-size-c-snapshot.yml
+++ b/tests/__snapshots__/small-key-size-c-snapshot.yml
@@ -1,0 +1,50 @@
+id: small-key-size-c
+snapshots:
+  ? |
+    void foo() {
+    size_t bad_size = 1024;
+    size_t good_size = 2048;
+    DH_generate_parameters_ex(NULL, bad_size);
+    DSA_generate_parameters_ex(NULL, bad_size);
+    EVP_PKEY_CTX_set_dh_paramgen_prime_len(NULL, bad_size);
+    EVP_PKEY_CTX_set_dsa_paramgen_bits(NULL, bad_size);
+    EVP_PKEY_CTX_set_rsa_keygen_bits(NULL, bad_size);
+    RSA_generate_key_ex(NULL, bad_size);
+    RSA_generate_key_fips(NULL, bad_size);}
+  : labels:
+    - source: DH_generate_parameters_ex(NULL, bad_size);
+      style: primary
+      start: 62
+      end: 104
+    - source: DH_generate_parameters_ex
+      style: secondary
+      start: 62
+      end: 87
+    - source: bad_size
+      style: secondary
+      start: 94
+      end: 102
+    - source: (NULL, bad_size)
+      style: secondary
+      start: 87
+      end: 103
+    - source: DH_generate_parameters_ex(NULL, bad_size)
+      style: secondary
+      start: 62
+      end: 103
+    - source: bad_size
+      style: secondary
+      start: 20
+      end: 28
+    - source: '1024'
+      style: secondary
+      start: 31
+      end: 35
+    - source: bad_size = 1024
+      style: secondary
+      start: 20
+      end: 35
+    - source: size_t bad_size = 1024;
+      style: secondary
+      start: 13
+      end: 36

--- a/tests/__snapshots__/std-return-data-c-snapshot.yml
+++ b/tests/__snapshots__/std-return-data-c-snapshot.yml
@@ -1,0 +1,68 @@
+id: std-return-data-c
+snapshots:
+  ? |-
+    int *return_vector_data() {
+    std::vector<int> v;
+    return v.data();
+    }
+  : labels:
+    - source: return v.data();
+      style: primary
+      start: 48
+      end: 64
+    - source: v
+      style: secondary
+      start: 55
+      end: 56
+    - source: v.data
+      style: secondary
+      start: 55
+      end: 61
+    - source: v.data()
+      style: secondary
+      start: 55
+      end: 63
+    - source: std
+      style: secondary
+      start: 28
+      end: 31
+    - source: vector
+      style: secondary
+      start: 33
+      end: 39
+    - source: vector
+      style: secondary
+      start: 33
+      end: 39
+    - source: vector<int
+      style: secondary
+      start: 33
+      end: 43
+    - source: int
+      style: secondary
+      start: 0
+      end: 3
+    - source: |-
+        int *return_vector_data() {
+        std::vector<int> v;
+        return v.data();
+        }
+      style: secondary
+      start: 0
+      end: 66
+    - source: v
+      style: secondary
+      start: 45
+      end: 46
+    - source: vector<int> v
+      style: secondary
+      start: 33
+      end: 46
+    - source: vector<int> v;
+      style: secondary
+      start: 33
+      end: 47
+    - source: std::vector<int> v;
+      style: secondary
+      start: 28
+      end: 47

--- a/tests/c/sizeof-this-c-test.yml
+++ b/tests/c/sizeof-this-c-test.yml
@@ -1,0 +1,12 @@
+id: sizeof-this-c
+valid:
+  - |
+    sizeof(*this);
+invalid:
+  - |
+    struct Foo {
+    uint64_t a;
+    uint8_t b;
+    size_t get_size() const {
+    return sizeof(this);
+    }

--- a/tests/c/small-key-size-c-test.yml
+++ b/tests/c/small-key-size-c-test.yml
@@ -1,0 +1,28 @@
+id: small-key-size-c
+valid:
+  - |
+    void foo() {
+    size_t bad_size = 1024;
+    size_t good_size = 2048;
+    DH_generate_parameters_ex(NULL, good_size);
+    DSA_generate_parameters_ex(NULL, good_size);
+    EVP_PKEY_CTX_set_dh_paramgen_prime_len(NULL, good_size);
+    EVP_PKEY_CTX_set_dsa_paramgen_bits(NULL, good_size);
+    EVP_PKEY_CTX_set_rsa_keygen_bits(NULL, good_size);
+    RSA_generate_key_ex(NULL, good_size);
+    RSA_generate_key_fips(NULL, good_size);}
+
+invalid:
+   - |
+     void foo() {
+     size_t bad_size = 1024;
+     size_t good_size = 2048;
+     DH_generate_parameters_ex(NULL, bad_size);
+     DSA_generate_parameters_ex(NULL, bad_size);
+     EVP_PKEY_CTX_set_dh_paramgen_prime_len(NULL, bad_size);
+     EVP_PKEY_CTX_set_dsa_paramgen_bits(NULL, bad_size);
+     EVP_PKEY_CTX_set_rsa_keygen_bits(NULL, bad_size);
+     RSA_generate_key_ex(NULL, bad_size);
+     RSA_generate_key_fips(NULL, bad_size);}
+ 
+

--- a/tests/c/std-return-data-c-test.yml
+++ b/tests/c/std-return-data-c-test.yml
@@ -1,0 +1,15 @@
+id: std-return-data-c
+valid:
+  - |
+    class Wrapper {
+    std::vector<int> v;
+    int *return_vector_begin_iterator() {
+    return v.data();
+    } 
+    }
+invalid:
+   - |
+     int *return_vector_data() {
+     std::vector<int> v;
+     return v.data();
+     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new security rules for C programming:
		- `sizeof-this-c`: Warns against misuse of `sizeof(this)` resulting in incorrect pointer size.
		- `small-key-size-c`: Alerts when cryptographic functions use key sizes smaller than 2048 bits.
		- `std-return-data-c`: Detects potential use-after-free vulnerabilities when returning pointers to local variables.
  
- **Tests**
	- Added test configurations to validate the new rules and ensure correct usage of `sizeof`, key sizes, and vector data returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->