### PR TITLE
Add security rules for detecting hard-coded secrets in C# and Python

### DIFF
--- a/rules/csharp/security/oracleconnectionstringbuilder-hardcoded-secret-csharp.yml
+++ b/rules/csharp/security/oracleconnectionstringbuilder-hardcoded-secret-csharp.yml
@@ -1,0 +1,247 @@
+id: oracleconnectionstringbuilder-hardcoded-secret-csharp
+language: csharp
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source
+  code, such as credentials, identifiers, and other types of sensitive data,
+  can be leaked and used by internal or external malicious actors. Use
+  environment variables to securely provide credentials and other secrets or
+  retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798]: Use of Hard-coded Credentials
+  [OWASP A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+       https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+utils:
+  match_assignment_without_brackets:
+    kind: assignment_expression
+    all:
+      - has:
+          stopBy: end
+          kind: member_access_expression
+          all:
+            - has:
+                stopBy: end
+                kind: identifier
+                field: expression
+                pattern: $B
+            - has:
+                stopBy: end
+                kind: identifier
+                field: name
+                regex: "^Password$"
+      - has:
+          stopBy: end
+          kind: string_literal
+          has:
+            stopBy: end
+            kind: string_literal_content
+    inside:
+      stopBy: end
+      kind: expression_statement
+      follows:
+        stopBy: end
+        kind: local_declaration_statement
+        all:
+          - has:
+              stopBy: end
+              kind: variable_declaration
+              has:
+                stopBy: end
+                kind: identifier
+                field: type
+                regex: "^OracleConnectionStringBuilder$"
+          - has:
+              stopBy: end
+              kind: variable_declarator
+              has:
+                stopBy: end
+                kind: identifier
+                pattern: $B
+          - has:
+              stopBy: end
+              kind: object_creation_expression
+  match_assignment_with_brackets:
+    kind: assignment_expression
+    all:
+      - has:
+          stopBy: end
+          kind: element_access_expression
+          all:
+            - has:
+                stopBy: end
+                kind: identifier
+                pattern: $B
+            - has:
+                stopBy: end
+                kind: bracketed_argument_list
+                field: subscript
+            - has:
+                stopBy: end
+                kind: argument
+            - has:
+                stopBy: end
+                kind: string_literal
+                has:
+                  stopBy: end
+                  kind: string_literal_content
+                  regex: "^Password$"
+              all:
+                - not:
+                    precedes:
+                      stopBy: end
+                      kind: element_access_expression
+                - not:
+                    precedes:
+                      stopBy: end
+                      kind: invocation_expression
+
+      - has:
+          stopBy: end
+          kind: string_literal
+          has:
+            stopBy: end
+            kind: string_literal_content
+    inside:
+      stopBy: end
+      kind: expression_statement
+      follows:
+        stopBy: end
+        kind: local_declaration_statement
+        all:
+          - has:
+              stopBy: end
+              kind: variable_declaration
+              has:
+                stopBy: end
+                kind: identifier
+                field: type
+                regex: "^OracleConnectionStringBuilder$"
+          - has:
+              stopBy: end
+              kind: variable_declarator
+              has:
+                stopBy: end
+                kind: identifier
+                field: name
+                pattern: $B
+          - has:
+              stopBy: end
+              kind: object_creation_expression
+  match_assignment_with_instance_above_with_bracket:
+    kind: assignment_expression
+    all:
+      - has:
+          stopBy: end
+          kind: element_access_expression
+          all:
+            - has:
+                stopBy: end
+                kind: identifier
+                field: expression
+                pattern: $N
+            - has:
+                stopBy: end
+                kind: bracketed_argument_list
+                field: subscript
+            - has:
+                stopBy: end
+                kind: argument
+            - has:
+                stopBy: end
+                kind: string_literal
+                has:
+                  stopBy: end
+                  kind: string_literal_content
+                  regex: "^Password$"
+              all:
+                - not:
+                    precedes:
+                      stopBy: end
+                      kind: element_access_expression
+                - not:
+                    precedes:
+                      stopBy: end
+                      kind: invocation_expression
+      - has:
+          stopBy: end
+          kind: string_literal
+          has:
+            stopBy: end
+            kind: string_literal_content
+
+    inside:
+      stopBy: end
+      kind: expression_statement
+      follows:
+        stopBy: end
+        kind: local_declaration_statement
+        all:
+          - has:
+              stopBy: end
+              kind: variable_declaration
+              has:
+                stopBy: end
+                kind: implicit_type
+          - has:
+              stopBy: end
+              kind: variable_declarator
+              has:
+                stopBy: end
+                kind: identifier
+                pattern: $N
+          - has:
+              stopBy: end
+              kind: object_creation_expression
+  match_assignment_with_instance_above_without_bracket:
+    kind: assignment_expression
+    all:
+      - has:
+          stopBy: end
+          kind: member_access_expression
+          all:
+            - has:
+                stopBy: end
+                kind: identifier
+                field: expression
+                pattern: $N
+            - has:
+                stopBy: end
+                kind: identifier
+                field: name
+                regex: "^Password$"
+      - has:
+          stopBy: end
+          kind: string_literal
+          has:
+            stopBy: end
+            kind: string_literal_content
+    inside:
+      stopBy: end
+      kind: expression_statement
+      follows:
+        stopBy: end
+        kind: local_declaration_statement
+        all:
+          - has:
+              stopBy: end
+              kind: variable_declaration
+              has:
+                stopBy: end
+                kind: implicit_type
+          - has:
+              stopBy: end
+              kind: variable_declarator
+              has:
+                stopBy: end
+                kind: identifier
+                pattern: $N
+          - has:
+              stopBy: end
+              kind: object_creation_expression
+rule:
+  any:
+    - matches: match_assignment_without_brackets
+    - matches: match_assignment_with_brackets
+    - matches: match_assignment_with_instance_above_with_bracket
+    - matches: match_assignment_with_instance_above_without_bracket

--- a/rules/python/security/python-elasticsearch-hardcoded-bearer-auth-python.yml
+++ b/rules/python/security/python-elasticsearch-hardcoded-bearer-auth-python.yml
@@ -1,0 +1,445 @@
+id: python-elasticsearch-hardcoded-bearer-auth-python
+severity: warning
+language: python
+message: >-
+      A secret is hard-coded in the application. Secrets stored in source
+      code, such as credentials, identifiers, and other types of sensitive data,
+      can be leaked and used by internal or external malicious actors. Use
+      environment variables to securely provide credentials and other secrets or
+      retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798] Use of Hard-coded Credentials.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+utils:
+  elasticsearch.Elasticsearch(..., bearer_auth="...",...):
+    # elasticsearch.Elasticsearch(..., bearer_auth="...",...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          regex: ^elasticsearch.Elasticsearch$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  regex: ^bearer_auth$
+              - has:
+                  stopBy: neighbor
+                  kind: string
+                  has:
+                    stopBy: end
+                    kind: string_content
+  elasticsearch.Elasticsearch(..., bearer_auth=$VAR,...)_with_instance:
+    # elasticsearch.Elasticsearch(..., bearer_auth="...",...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          regex: ^elasticsearch.Elasticsearch$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  regex: ^bearer_auth$
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  nthChild: 2
+                  pattern: $P
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: neighbor
+              kind: assignment
+              all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $P
+              - has:
+                  stopBy: neighbor
+                  kind: string
+                  has:
+                    stopBy: neighbor
+                    kind: string_content
+  Elasticsearch(..., bearer_auth="...",...):
+    # elasticsearch.Elasticsearch(..., bearer_auth="...",...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: identifier
+          regex: ^Elasticsearch$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  regex: ^bearer_auth$
+              - has:
+                  stopBy: neighbor
+                  kind: string
+                  has:
+                    stopBy: end
+                    kind: string_content
+      - inside:
+          stopBy: end
+          kind: module
+          has:
+            stopBy: end
+            kind: import_from_statement
+            pattern: from elasticsearch import Elasticsearch
+  Elasticsearch(..., bearer_auth=$VAR,...)_with_instance:
+    # elasticsearch.Elasticsearch(..., bearer_auth="...",...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: identifier
+          regex: ^Elasticsearch$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  regex: ^bearer_auth$
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  nthChild: 2
+                  pattern: $P
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: neighbor
+              kind: assignment
+              all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $P
+              - has:
+                  stopBy: neighbor
+                  kind: string
+                  has:
+                    stopBy: neighbor
+                    kind: string_content
+      - inside:
+          stopBy: end
+          kind: module
+          has:
+            stopBy: end
+            kind: import_from_statement
+            pattern: from elasticsearch import Elasticsearch
+  $ES.options(..., bearer_auth="...",...):
+    # $ES.options(..., bearer_auth="...",...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                pattern: $I
+                nthChild: 1
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^options$
+      - has:
+                stopBy: neighbor
+                kind: argument_list
+                all:
+                  - has:
+                      stopBy: end
+                      kind: keyword_argument
+                      all:
+                        - has:
+                            stopBy: neighbor
+                            kind: identifier
+                            regex: ^bearer_auth$
+                        - has:
+                            stopBy: neighbor
+                            kind: string
+                            has:
+                              stopBy: neighbor
+                              kind: string_content
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: neighbor
+              kind: assignment
+              all:
+                - has:
+                    stopBy: neighbor
+                    kind: identifier
+                    pattern: $I
+                - has:
+                    stopBy: neighbor
+                    kind: call
+                    pattern: elasticsearch.Elasticsearch()
+  $ES.options(..., bearer_auth=$VAR,...)_with_instance:
+    # $ES.options(..., bearer_auth="...",...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                pattern: $I
+                nthChild: 1
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^options$
+      - has:
+                stopBy: neighbor
+                kind: argument_list
+                all:
+                  - has:
+                      stopBy: end
+                      kind: keyword_argument
+                      all:
+                        - has:
+                            stopBy: neighbor
+                            kind: identifier
+                            regex: ^bearer_auth$
+                        - has:
+                            stopBy: neighbor
+                            kind: identifier
+                            pattern: $C
+                            nthChild: 2
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: neighbor
+              kind: assignment
+              all:
+                - has:
+                    stopBy: neighbor
+                    kind: identifier
+                    pattern: $I
+                - has:
+                    stopBy: neighbor
+                    kind: call
+                    pattern: elasticsearch.Elasticsearch()
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: end
+              kind: assignment
+              all:
+                - has:
+                    stopBy: neighbor
+                    kind: identifier
+                    pattern: $C
+                - has:
+                    stopBy: neighbor
+                    kind: string
+                    has:
+                      stopBy: neighbor
+                      kind: string_content
+  $ES.options(..., bearer_auth="...",...)_2:
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                pattern: $J
+                nthChild: 1
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^options$
+      - has:
+                stopBy: neighbor
+                kind: argument_list
+                all:
+                  - has:
+                      stopBy: end
+                      kind: keyword_argument
+                      all:
+                        - has:
+                            stopBy: neighbor
+                            kind: identifier
+                            regex: ^bearer_auth$
+                        - has:
+                            stopBy: neighbor
+                            kind: string
+                            has:
+                              stopBy: neighbor
+                              kind: string_content
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+             stopBy: neighbor
+             kind: assignment
+             all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $J
+              - has:
+                  stopBy: neighbor
+                  kind: call
+                  has:
+                    stopBy: neighbor
+                    kind: identifier
+                    regex: ^Elasticsearch$
+      - inside:
+          stopBy: end
+          kind: module
+          has:
+            stopBy: end
+            kind: import_from_statement
+            pattern: from elasticsearch import Elasticsearch
+  $ES.options(..., bearer_auth=$VAR,...)_with_instance_2:
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                pattern: $J
+                nthChild: 1
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^options$
+      - has:
+                stopBy: neighbor
+                kind: argument_list
+                all:
+                  - has:
+                      stopBy: end
+                      kind: keyword_argument
+                      all:
+                        - has:
+                            stopBy: neighbor
+                            kind: identifier
+                            regex: ^bearer_auth$
+                        - has:
+                            stopBy: neighbor
+                            kind: identifier
+                            pattern: $R
+                            nthChild: 2
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+             stopBy: neighbor
+             kind: assignment
+             all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $J
+              - has:
+                  stopBy: neighbor
+                  kind: call
+                  has:
+                    stopBy: neighbor
+                    kind: identifier
+                    regex: ^Elasticsearch$
+      - inside:
+          stopBy: end
+          kind: module
+          has:
+            stopBy: end
+            kind: import_from_statement
+            pattern: from elasticsearch import Elasticsearch
+      - inside:
+          stopBy: end
+          kind: expression_statement
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: neighbor
+              kind: assignment
+              all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $R
+              - has:
+                  stopBy: neighbor
+                  kind: string
+                  has:
+                    stopBy: neighbor
+                    kind: string_content
+rule:
+  kind: call
+  any:
+    - matches: elasticsearch.Elasticsearch(..., bearer_auth="...",...)
+    - matches: elasticsearch.Elasticsearch(..., bearer_auth=$VAR,...)_with_instance
+    - matches: Elasticsearch(..., bearer_auth="...",...)
+    - matches: Elasticsearch(..., bearer_auth=$VAR,...)_with_instance
+    - matches: $ES.options(..., bearer_auth="...",...)
+    - matches: $ES.options(..., bearer_auth=$VAR,...)_with_instance
+    - matches: $ES.options(..., bearer_auth="...",...)_2
+    - matches: $ES.options(..., bearer_auth=$VAR,...)_with_instance_2

--- a/rules/python/security/python-peewee-mysql-empty-password-python.yml
+++ b/rules/python/security/python-peewee-mysql-empty-password-python.yml
@@ -1,0 +1,214 @@
+id: python-peewee-mysql-empty-password-python
+severity: warning
+language: python
+message: >-
+      The application creates a database connection with an empty password.
+      This can lead to unauthorized access by either an internal or external
+      malicious actor. To prevent this vulnerability, enforce authentication
+      when connecting to a database by using environment variables to securely
+      provide credentials or retrieving them from a secure vault or HSM
+      (Hardware Security Module).
+note: >-
+  [CWE-287] Improper Authentication.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+utils:
+  $DB(..., password="...",...):
+    # $DB(..., password="...",...)
+    kind: call
+    all:
+    - has:
+        stopBy: neighbor
+        pattern: $DB
+        regex: ^MySQLDatabase|peewee.MySQLDatabase|MySQLConnectorDatabase|playhouse.mysql_ext.MySQLConnectorDatabase|MariaDBConnectorDatabase|playhouse.mysql_ext.MariaDBConnectorDatabase|PooledMySQLDatabase|playhouse.pool.PooledMySQLDatabase$
+    - has:
+        stopBy: neighbor
+        kind: argument_list
+        has:
+          stopBy: end
+          kind: keyword_argument
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^password|passwd$
+            - has:
+                stopBy: neighbor
+                kind: string
+                not:
+                  has:
+                   stopBy: neighbor
+                   kind: string_content
+  $DB(..., password=$VAR,...):
+    # $DB(..., password=$VAR,...)_with_instance
+    kind: call
+    all:
+    - has:
+        stopBy: neighbor
+        pattern: $DB
+        regex: ^MySQLDatabase|peewee.MySQLDatabase|MySQLConnectorDatabase|playhouse.mysql_ext.MySQLConnectorDatabase|MariaDBConnectorDatabase|playhouse.mysql_ext.MariaDBConnectorDatabase|PooledMySQLDatabase|playhouse.pool.PooledMySQLDatabase$
+    - has:
+        stopBy: neighbor
+        kind: argument_list
+        has:
+          stopBy: end
+          kind: keyword_argument
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^password|passwd$
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                pattern: $R
+                nthChild: 2
+    - inside:
+        stopBy: end
+        kind: expression_statement
+        follows: 
+          stopBy: end
+          kind: expression_statement
+          has:
+              stopBy: neighbor
+              kind: assignment
+              all:
+                - has:
+                    stopBy: neighbor
+                    kind: identifier
+                    pattern: $R
+                - has:
+                    stopBy: neighbor
+                    kind: string
+                    not:
+                      has:
+                       stopBy: neighbor
+                       kind: string_content
+  $X.init(..., password="...", ...):
+    # $X.init(..., password="...", ...)
+    kind: call
+    all:
+    - has:
+        stopBy: neighbor
+        kind: attribute
+        all:
+          - has:
+              stopBy: neighbor
+              pattern: $D
+              nthChild: 1
+          - has:
+              stopBy: neighbor
+              kind: identifier
+              regex: ^init$
+    - has:
+        stopBy: neighbor
+        kind: argument_list
+        has:
+          stopBy: end
+          kind: keyword_argument
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^password|passwd$
+            - has:
+                stopBy: neighbor
+                kind: string
+                not:
+                  has:
+                   stopBy: neighbor
+                   kind: string_content
+    - inside:
+        stopBy: end
+        kind: expression_statement
+        follows:
+          stopBy: end
+          kind: expression_statement
+          has:
+            stopBy: neighbor
+            kind: assignment
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $D
+              - has:
+                  stopBy: neighbor
+                  regex: ^MySQLDatabase|peewee.MySQLDatabase|MySQLConnectorDatabase|playhouse.mysql_ext.MySQLConnectorDatabase|MariaDBConnectorDatabase|playhouse.mysql_ext.MariaDBConnectorDatabase|PooledMySQLDatabase|playhouse.pool.PooledMySQLDatabase$
+  $X.init(..., password=$VAR, ...):
+    # $X.init(..., password=$VAR, ...)
+    kind: call
+    all:
+    - has:
+        stopBy: neighbor
+        kind: attribute
+        all:
+          - has:
+              stopBy: neighbor
+              pattern: $D
+              nthChild: 1
+          - has:
+              stopBy: neighbor
+              kind: identifier
+              regex: ^init$
+    - has:
+        stopBy: neighbor
+        kind: argument_list
+        has:
+          stopBy: end
+          kind: keyword_argument
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^password|passwd$
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                pattern: $PASS
+                nthChild: 2
+    - inside:
+        stopBy: end
+        kind: expression_statement
+        follows:
+          stopBy: end
+          kind: expression_statement
+          has:
+            stopBy: neighbor
+            kind: assignment
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $D
+              - has:
+                  stopBy: neighbor
+                  regex: ^MySQLDatabase|peewee.MySQLDatabase|MySQLConnectorDatabase|playhouse.mysql_ext.MySQLConnectorDatabase|MariaDBConnectorDatabase|playhouse.mysql_ext.MariaDBConnectorDatabase|PooledMySQLDatabase|playhouse.pool.PooledMySQLDatabase$
+    - inside:
+        stopBy: end
+        kind: expression_statement
+        follows: 
+          stopBy: end
+          kind: expression_statement
+          has:
+              stopBy: neighbor
+              kind: assignment
+              all:
+                - has:
+                    stopBy: neighbor
+                    kind: identifier
+                    pattern: $PASS
+                - has:
+                    stopBy: neighbor
+                    kind: string
+                    not:
+                      has:
+                       stopBy: neighbor
+                       kind: string_content
+rule:
+  kind: call
+  any:
+    - matches: $DB(..., password="...",...)
+    - matches: $DB(..., password=$VAR,...)
+    - matches: $X.init(..., password="...", ...)
+    - matches: $X.init(..., password=$VAR, ...)

--- a/tests/__snapshots__/oracleconnectionstringbuilder-hardcoded-secret-csharp-snapshot.yml
+++ b/tests/__snapshots__/oracleconnectionstringbuilder-hardcoded-secret-csharp-snapshot.yml
@@ -1,0 +1,262 @@
+id: oracleconnectionstringbuilder-hardcoded-secret-csharp
+snapshots:
+  ? |
+    private OracleConnectionStringBuilder GetConnection(args)
+    {
+    OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder();
+    builder.Password = "reee!";
+    }
+  : labels:
+    - source: builder.Password = "reee!"
+      style: primary
+      start: 137
+      end: 163
+    - source: builder
+      style: secondary
+      start: 137
+      end: 144
+    - source: Password
+      style: secondary
+      start: 145
+      end: 153
+    - source: builder.Password
+      style: secondary
+      start: 137
+      end: 153
+    - source: reee!
+      style: secondary
+      start: 157
+      end: 162
+    - source: '"reee!"'
+      style: secondary
+      start: 156
+      end: 163
+    - source: OracleConnectionStringBuilder
+      style: secondary
+      start: 60
+      end: 89
+    - source: OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder()
+      style: secondary
+      start: 60
+      end: 135
+    - source: builder
+      style: secondary
+      start: 90
+      end: 97
+    - source: builder = new OracleConnectionStringBuilder()
+      style: secondary
+      start: 90
+      end: 135
+    - source: new OracleConnectionStringBuilder()
+      style: secondary
+      start: 100
+      end: 135
+    - source: OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder();
+      style: secondary
+      start: 60
+      end: 136
+    - source: builder.Password = "reee!";
+      style: secondary
+      start: 137
+      end: 164
+  ? |
+    private OracleConnectionStringBuilder GetConnection(args)
+    {
+    OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder();
+    builder["Password"] = "reee!";
+    }
+  : labels:
+    - source: builder["Password"] = "reee!"
+      style: primary
+      start: 137
+      end: 166
+    - source: builder
+      style: secondary
+      start: 137
+      end: 144
+    - source: '["Password"]'
+      style: secondary
+      start: 144
+      end: 156
+    - source: '"Password"'
+      style: secondary
+      start: 145
+      end: 155
+    - source: Password
+      style: secondary
+      start: 146
+      end: 154
+    - source: '"Password"'
+      style: secondary
+      start: 145
+      end: 155
+    - source: builder["Password"]
+      style: secondary
+      start: 137
+      end: 156
+    - source: Password
+      style: secondary
+      start: 146
+      end: 154
+    - source: '"Password"'
+      style: secondary
+      start: 145
+      end: 155
+    - source: OracleConnectionStringBuilder
+      style: secondary
+      start: 60
+      end: 89
+    - source: OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder()
+      style: secondary
+      start: 60
+      end: 135
+    - source: builder
+      style: secondary
+      start: 90
+      end: 97
+    - source: builder = new OracleConnectionStringBuilder()
+      style: secondary
+      start: 90
+      end: 135
+    - source: new OracleConnectionStringBuilder()
+      style: secondary
+      start: 100
+      end: 135
+    - source: OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder();
+      style: secondary
+      start: 60
+      end: 136
+    - source: builder["Password"] = "reee!";
+      style: secondary
+      start: 137
+      end: 167
+  ? |
+    private OracleConnectionStringBuilder GetConnection(args)
+    {
+    var cb = new OracleConnectionStringBuilder();
+    cb.Password = "reee!";
+    }
+  : labels:
+    - source: cb.Password = "reee!"
+      style: primary
+      start: 106
+      end: 127
+    - source: cb
+      style: secondary
+      start: 106
+      end: 108
+    - source: Password
+      style: secondary
+      start: 109
+      end: 117
+    - source: cb.Password
+      style: secondary
+      start: 106
+      end: 117
+    - source: reee!
+      style: secondary
+      start: 121
+      end: 126
+    - source: '"reee!"'
+      style: secondary
+      start: 120
+      end: 127
+    - source: var
+      style: secondary
+      start: 60
+      end: 63
+    - source: var cb = new OracleConnectionStringBuilder()
+      style: secondary
+      start: 60
+      end: 104
+    - source: cb
+      style: secondary
+      start: 64
+      end: 66
+    - source: cb = new OracleConnectionStringBuilder()
+      style: secondary
+      start: 64
+      end: 104
+    - source: new OracleConnectionStringBuilder()
+      style: secondary
+      start: 69
+      end: 104
+    - source: var cb = new OracleConnectionStringBuilder();
+      style: secondary
+      start: 60
+      end: 105
+    - source: cb.Password = "reee!";
+      style: secondary
+      start: 106
+      end: 128
+  ? |
+    private OracleConnectionStringBuilder GetConnection(args)
+    {
+    var cb = new OracleConnectionStringBuilder();
+    cb["Password"] = "reee!";
+    }
+  : labels:
+    - source: cb["Password"] = "reee!"
+      style: primary
+      start: 106
+      end: 130
+    - source: cb
+      style: secondary
+      start: 106
+      end: 108
+    - source: '["Password"]'
+      style: secondary
+      start: 108
+      end: 120
+    - source: '"Password"'
+      style: secondary
+      start: 109
+      end: 119
+    - source: Password
+      style: secondary
+      start: 110
+      end: 118
+    - source: '"Password"'
+      style: secondary
+      start: 109
+      end: 119
+    - source: cb["Password"]
+      style: secondary
+      start: 106
+      end: 120
+    - source: Password
+      style: secondary
+      start: 110
+      end: 118
+    - source: '"Password"'
+      style: secondary
+      start: 109
+      end: 119
+    - source: var
+      style: secondary
+      start: 60
+      end: 63
+    - source: var cb = new OracleConnectionStringBuilder()
+      style: secondary
+      start: 60
+      end: 104
+    - source: cb
+      style: secondary
+      start: 64
+      end: 66
+    - source: cb = new OracleConnectionStringBuilder()
+      style: secondary
+      start: 64
+      end: 104
+    - source: new OracleConnectionStringBuilder()
+      style: secondary
+      start: 69
+      end: 104
+    - source: var cb = new OracleConnectionStringBuilder();
+      style: secondary
+      start: 60
+      end: 105
+    - source: cb["Password"] = "reee!";
+      style: secondary
+      start: 106
+      end: 131

--- a/tests/__snapshots__/python-elasticsearch-hardcoded-bearer-auth-python-snapshot.yml
+++ b/tests/__snapshots__/python-elasticsearch-hardcoded-bearer-auth-python-snapshot.yml
@@ -1,0 +1,298 @@
+id: python-elasticsearch-hardcoded-bearer-auth-python
+snapshots:
+  ? |
+    from elasticsearch import Elasticsearch
+    es = Elasticsearch(
+    "https://localhost:9200",
+    bearer_auth="token-value"
+    )
+  : labels:
+    - source: |-
+        Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth="token-value"
+        )
+      style: primary
+      start: 45
+      end: 113
+    - source: Elasticsearch
+      style: secondary
+      start: 45
+      end: 58
+    - source: bearer_auth
+      style: secondary
+      start: 86
+      end: 97
+    - source: token-value
+      style: secondary
+      start: 99
+      end: 110
+    - source: '"token-value"'
+      style: secondary
+      start: 98
+      end: 111
+    - source: bearer_auth="token-value"
+      style: secondary
+      start: 86
+      end: 111
+    - source: |-
+        (
+        "https://localhost:9200",
+        bearer_auth="token-value"
+        )
+      style: secondary
+      start: 58
+      end: 113
+    - source: from elasticsearch import Elasticsearch
+      style: secondary
+      start: 0
+      end: 39
+    - source: |
+        from elasticsearch import Elasticsearch
+        es = Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth="token-value"
+        )
+      style: secondary
+      start: 0
+      end: 114
+  ? |
+    from elasticsearch import Elasticsearch
+    pswd = "token-value"
+    es = Elasticsearch(
+    "https://localhost:9200",
+    bearer_auth=pswd
+    )
+  : labels:
+    - source: |-
+        Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: primary
+      start: 66
+      end: 125
+    - source: Elasticsearch
+      style: secondary
+      start: 66
+      end: 79
+    - source: bearer_auth
+      style: secondary
+      start: 107
+      end: 118
+    - source: pswd
+      style: secondary
+      start: 119
+      end: 123
+    - source: bearer_auth=pswd
+      style: secondary
+      start: 107
+      end: 123
+    - source: |-
+        (
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: secondary
+      start: 79
+      end: 125
+    - source: pswd
+      style: secondary
+      start: 40
+      end: 44
+    - source: token-value
+      style: secondary
+      start: 48
+      end: 59
+    - source: '"token-value"'
+      style: secondary
+      start: 47
+      end: 60
+    - source: pswd = "token-value"
+      style: secondary
+      start: 40
+      end: 60
+    - source: pswd = "token-value"
+      style: secondary
+      start: 40
+      end: 60
+    - source: |-
+        es = Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: secondary
+      start: 61
+      end: 125
+    - source: from elasticsearch import Elasticsearch
+      style: secondary
+      start: 0
+      end: 39
+    - source: |
+        from elasticsearch import Elasticsearch
+        pswd = "token-value"
+        es = Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: secondary
+      start: 0
+      end: 126
+  ? |
+    from elasticsearch import Elasticsearch
+    pswd = "token-value"
+    es = Elasticsearch(
+    "https://localhost:9200",
+    bearer_auth=pswd
+    )
+    es.options(
+    bearer_auth="password"
+    ).indices.get(index="*")
+  : labels:
+    - source: |-
+        Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: primary
+      start: 66
+      end: 125
+    - source: Elasticsearch
+      style: secondary
+      start: 66
+      end: 79
+    - source: bearer_auth
+      style: secondary
+      start: 107
+      end: 118
+    - source: pswd
+      style: secondary
+      start: 119
+      end: 123
+    - source: bearer_auth=pswd
+      style: secondary
+      start: 107
+      end: 123
+    - source: |-
+        (
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: secondary
+      start: 79
+      end: 125
+    - source: pswd
+      style: secondary
+      start: 40
+      end: 44
+    - source: token-value
+      style: secondary
+      start: 48
+      end: 59
+    - source: '"token-value"'
+      style: secondary
+      start: 47
+      end: 60
+    - source: pswd = "token-value"
+      style: secondary
+      start: 40
+      end: 60
+    - source: pswd = "token-value"
+      style: secondary
+      start: 40
+      end: 60
+    - source: |-
+        es = Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: secondary
+      start: 61
+      end: 125
+    - source: from elasticsearch import Elasticsearch
+      style: secondary
+      start: 0
+      end: 39
+    - source: |
+        from elasticsearch import Elasticsearch
+        pswd = "token-value"
+        es = Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+        es.options(
+        bearer_auth="password"
+        ).indices.get(index="*")
+      style: secondary
+      start: 0
+      end: 186
+  ? "from elasticsearch import Elasticsearch\npswd = \"token-value\"\nes = Elasticsearch(\n\"https://localhost:9200\",\nbearer_auth=pswd\n)\npassword=\"bsdhsd\"\nes.options(\nbearer_auth=password\n).indices.get(index=\"*\") \n"
+  : labels:
+    - source: |-
+        Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: primary
+      start: 66
+      end: 125
+    - source: Elasticsearch
+      style: secondary
+      start: 66
+      end: 79
+    - source: bearer_auth
+      style: secondary
+      start: 107
+      end: 118
+    - source: pswd
+      style: secondary
+      start: 119
+      end: 123
+    - source: bearer_auth=pswd
+      style: secondary
+      start: 107
+      end: 123
+    - source: |-
+        (
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: secondary
+      start: 79
+      end: 125
+    - source: pswd
+      style: secondary
+      start: 40
+      end: 44
+    - source: token-value
+      style: secondary
+      start: 48
+      end: 59
+    - source: '"token-value"'
+      style: secondary
+      start: 47
+      end: 60
+    - source: pswd = "token-value"
+      style: secondary
+      start: 40
+      end: 60
+    - source: pswd = "token-value"
+      style: secondary
+      start: 40
+      end: 60
+    - source: |-
+        es = Elasticsearch(
+        "https://localhost:9200",
+        bearer_auth=pswd
+        )
+      style: secondary
+      start: 61
+      end: 125
+    - source: from elasticsearch import Elasticsearch
+      style: secondary
+      start: 0
+      end: 39
+    - source: "from elasticsearch import Elasticsearch\npswd = \"token-value\"\nes = Elasticsearch(\n\"https://localhost:9200\",\nbearer_auth=pswd\n)\npassword=\"bsdhsd\"\nes.options(\nbearer_auth=password\n).indices.get(index=\"*\") \n"
+      style: secondary
+      start: 0
+      end: 203

--- a/tests/__snapshots__/python-peewee-mysql-empty-password-python-snapshot.yml
+++ b/tests/__snapshots__/python-peewee-mysql-empty-password-python-snapshot.yml
@@ -1,0 +1,284 @@
+id: python-peewee-mysql-empty-password-python
+snapshots:
+  ? |
+    database = MySQLDatabase()
+    database.init('database_name', host='localhost', user='app', password='')
+  : labels:
+    - source: database.init('database_name', host='localhost', user='app', password='')
+      style: primary
+      start: 27
+      end: 100
+    - source: database
+      style: secondary
+      start: 27
+      end: 35
+    - source: init
+      style: secondary
+      start: 36
+      end: 40
+    - source: database.init
+      style: secondary
+      start: 27
+      end: 40
+    - source: password
+      style: secondary
+      start: 88
+      end: 96
+    - source: ''''''
+      style: secondary
+      start: 97
+      end: 99
+    - source: password=''
+      style: secondary
+      start: 88
+      end: 99
+    - source: ('database_name', host='localhost', user='app', password='')
+      style: secondary
+      start: 40
+      end: 100
+    - source: database
+      style: secondary
+      start: 0
+      end: 8
+    - source: MySQLDatabase()
+      style: secondary
+      start: 11
+      end: 26
+    - source: database = MySQLDatabase()
+      style: secondary
+      start: 0
+      end: 26
+    - source: database = MySQLDatabase()
+      style: secondary
+      start: 0
+      end: 26
+    - source: database.init('database_name', host='localhost', user='app', password='')
+      style: secondary
+      start: 27
+      end: 100
+  ? |
+    database = MySQLDatabase()
+    pswd = ""
+    database.init('database_name', host='localhost', user='app', password=pswd)
+  : labels:
+    - source: database.init('database_name', host='localhost', user='app', password=pswd)
+      style: primary
+      start: 37
+      end: 112
+    - source: database
+      style: secondary
+      start: 37
+      end: 45
+    - source: init
+      style: secondary
+      start: 46
+      end: 50
+    - source: database.init
+      style: secondary
+      start: 37
+      end: 50
+    - source: password
+      style: secondary
+      start: 98
+      end: 106
+    - source: pswd
+      style: secondary
+      start: 107
+      end: 111
+    - source: password=pswd
+      style: secondary
+      start: 98
+      end: 111
+    - source: ('database_name', host='localhost', user='app', password=pswd)
+      style: secondary
+      start: 50
+      end: 112
+    - source: database
+      style: secondary
+      start: 0
+      end: 8
+    - source: MySQLDatabase()
+      style: secondary
+      start: 11
+      end: 26
+    - source: database = MySQLDatabase()
+      style: secondary
+      start: 0
+      end: 26
+    - source: database = MySQLDatabase()
+      style: secondary
+      start: 0
+      end: 26
+    - source: database.init('database_name', host='localhost', user='app', password=pswd)
+      style: secondary
+      start: 37
+      end: 112
+    - source: pswd
+      style: secondary
+      start: 27
+      end: 31
+    - source: '""'
+      style: secondary
+      start: 34
+      end: 36
+    - source: pswd = ""
+      style: secondary
+      start: 27
+      end: 36
+    - source: pswd = ""
+      style: secondary
+      start: 27
+      end: 36
+    - source: database.init('database_name', host='localhost', user='app', password=pswd)
+      style: secondary
+      start: 37
+      end: 112
+  ? "mysql_db1 = MySQLDatabase('my_app', user='app', password='', host='10.1.0.8', port=3306) \n"
+  : labels:
+    - source: MySQLDatabase('my_app', user='app', password='', host='10.1.0.8', port=3306)
+      style: primary
+      start: 12
+      end: 88
+    - source: MySQLDatabase
+      style: secondary
+      start: 12
+      end: 25
+    - source: password
+      style: secondary
+      start: 48
+      end: 56
+    - source: ''''''
+      style: secondary
+      start: 57
+      end: 59
+    - source: password=''
+      style: secondary
+      start: 48
+      end: 59
+    - source: ('my_app', user='app', password='', host='10.1.0.8', port=3306)
+      style: secondary
+      start: 25
+      end: 88
+  ? |
+    pool = PooledMySQLDatabase('my_app', user='app', passwd='', host='10.1.0.9', port=5432)
+  : labels:
+    - source: PooledMySQLDatabase('my_app', user='app', passwd='', host='10.1.0.9', port=5432)
+      style: primary
+      start: 7
+      end: 87
+    - source: PooledMySQLDatabase
+      style: secondary
+      start: 7
+      end: 26
+    - source: passwd
+      style: secondary
+      start: 49
+      end: 55
+    - source: ''''''
+      style: secondary
+      start: 56
+      end: 58
+    - source: passwd=''
+      style: secondary
+      start: 49
+      end: 58
+    - source: ('my_app', user='app', passwd='', host='10.1.0.9', port=5432)
+      style: secondary
+      start: 26
+      end: 87
+  ? |
+    pswd = ""
+    my_db2 = MySQLDatabase('my_app', user='app', passwd=pswd, host='10.1.0.8', port=3306)
+  : labels:
+    - source: MySQLDatabase('my_app', user='app', passwd=pswd, host='10.1.0.8', port=3306)
+      style: primary
+      start: 19
+      end: 95
+    - source: MySQLDatabase
+      style: secondary
+      start: 19
+      end: 32
+    - source: passwd
+      style: secondary
+      start: 55
+      end: 61
+    - source: pswd
+      style: secondary
+      start: 62
+      end: 66
+    - source: passwd=pswd
+      style: secondary
+      start: 55
+      end: 66
+    - source: ('my_app', user='app', passwd=pswd, host='10.1.0.8', port=3306)
+      style: secondary
+      start: 32
+      end: 95
+    - source: pswd
+      style: secondary
+      start: 0
+      end: 4
+    - source: '""'
+      style: secondary
+      start: 7
+      end: 9
+    - source: pswd = ""
+      style: secondary
+      start: 0
+      end: 9
+    - source: pswd = ""
+      style: secondary
+      start: 0
+      end: 9
+    - source: my_db2 = MySQLDatabase('my_app', user='app', passwd=pswd, host='10.1.0.8', port=3306)
+      style: secondary
+      start: 10
+      end: 95
+  ? |
+    pswd = ""
+    my_db4 = MySQLConnectorDatabase('my_app', user='app', passwd=pswd, host='10.1.0.9', port=5432)
+  : labels:
+    - source: MySQLConnectorDatabase('my_app', user='app', passwd=pswd, host='10.1.0.9', port=5432)
+      style: primary
+      start: 19
+      end: 104
+    - source: MySQLConnectorDatabase
+      style: secondary
+      start: 19
+      end: 41
+    - source: passwd
+      style: secondary
+      start: 64
+      end: 70
+    - source: pswd
+      style: secondary
+      start: 71
+      end: 75
+    - source: passwd=pswd
+      style: secondary
+      start: 64
+      end: 75
+    - source: ('my_app', user='app', passwd=pswd, host='10.1.0.9', port=5432)
+      style: secondary
+      start: 41
+      end: 104
+    - source: pswd
+      style: secondary
+      start: 0
+      end: 4
+    - source: '""'
+      style: secondary
+      start: 7
+      end: 9
+    - source: pswd = ""
+      style: secondary
+      start: 0
+      end: 9
+    - source: pswd = ""
+      style: secondary
+      start: 0
+      end: 9
+    - source: my_db4 = MySQLConnectorDatabase('my_app', user='app', passwd=pswd, host='10.1.0.9', port=5432)
+      style: secondary
+      start: 10
+      end: 104

--- a/tests/csharp/oracleconnectionstringbuilder-hardcoded-secret-csharp-test.yml
+++ b/tests/csharp/oracleconnectionstringbuilder-hardcoded-secret-csharp-test.yml
@@ -1,0 +1,29 @@
+id: oracleconnectionstringbuilder-hardcoded-secret-csharp
+valid:
+  - |
+    builder.Password = args[1];
+invalid:
+  - |
+    private OracleConnectionStringBuilder GetConnection(args)
+    {
+    OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder();
+    builder.Password = "reee!";
+    }
+  - |
+    private OracleConnectionStringBuilder GetConnection(args)
+    {
+    OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder();
+    builder["Password"] = "reee!";
+    }
+  - |
+    private OracleConnectionStringBuilder GetConnection(args)
+    {
+    var cb = new OracleConnectionStringBuilder();
+    cb["Password"] = "reee!";
+    }
+  - |
+    private OracleConnectionStringBuilder GetConnection(args)
+    {
+    var cb = new OracleConnectionStringBuilder();
+    cb.Password = "reee!";
+    }

--- a/tests/python/python-elasticsearch-hardcoded-bearer-auth-python-test.yml
+++ b/tests/python/python-elasticsearch-hardcoded-bearer-auth-python-test.yml
@@ -1,0 +1,42 @@
+id: python-elasticsearch-hardcoded-bearer-auth-python
+valid:
+  - |
+    es = Elasticsearch("https://localhost:9200");
+    
+invalid:
+  - |
+    from elasticsearch import Elasticsearch
+    es = Elasticsearch(
+    "https://localhost:9200",
+    bearer_auth="token-value"
+    )
+  - |
+    from elasticsearch import Elasticsearch
+    pswd = "token-value"
+    es = Elasticsearch(
+    "https://localhost:9200",
+    bearer_auth=pswd
+    )
+  - |
+    from elasticsearch import Elasticsearch
+    pswd = "token-value"
+    es = Elasticsearch(
+    "https://localhost:9200",
+    bearer_auth=pswd
+    )
+    es.options(
+    bearer_auth="password"
+    ).indices.get(index="*")
+  - |
+    from elasticsearch import Elasticsearch
+    pswd = "token-value"
+    es = Elasticsearch(
+    "https://localhost:9200",
+    bearer_auth=pswd
+    )
+    password="bsdhsd"
+    es.options(
+    bearer_auth=password
+    ).indices.get(index="*") 
+
+

--- a/tests/python/python-peewee-mysql-empty-password-python-test.yml
+++ b/tests/python/python-peewee-mysql-empty-password-python-test.yml
@@ -1,0 +1,24 @@
+id: python-peewee-mysql-empty-password-python
+valid:
+  - |
+    mysql_db1 = MySQLDatabe('my_app', user='app', password='db_password', host='10.1.0.8', port=3306)
+invalid:
+  - |
+    mysql_db1 = MySQLDatabase('my_app', user='app', password='', host='10.1.0.8', port=3306) 
+  - |
+    pswd = ""
+    my_db2 = MySQLDatabase('my_app', user='app', passwd=pswd, host='10.1.0.8', port=3306)
+  - |
+    database = MySQLDatabase()
+    database.init('database_name', host='localhost', user='app', password='')
+  - |
+    database = MySQLDatabase()
+    pswd = ""
+    database.init('database_name', host='localhost', user='app', password=pswd)
+  - |
+    pswd = ""
+    my_db4 = MySQLConnectorDatabase('my_app', user='app', passwd=pswd, host='10.1.0.9', port=5432)
+  - |
+    pool = PooledMySQLDatabase('my_app', user='app', passwd='', host='10.1.0.9', port=5432)
+
+    


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced security rules to detect hard-coded secrets in C# and Python applications, including:
		- Hard-coded secrets in `OracleConnectionStringBuilder` for C#.
		- Hard-coded bearer tokens in Elasticsearch for Python.
		- Empty passwords in Peewee ORM with MySQL for Python.
- **Tests**
	- Added comprehensive test cases for the new security rules, including valid and invalid scenarios for each rule across C# and Python implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->