### PR TITLE
Add Security Rules for Flask, psycopg2, and urllib3 in Python Applications

### DIFF
--- a/rules/python/security/hashids-with-flask-secret-python.yml
+++ b/rules/python/security/hashids-with-flask-secret-python.yml
@@ -1,0 +1,201 @@
+id: hashids-with-flask-secret-python
+severity: warning
+language: python
+message: >-
+      The Flask secret key is used as salt in HashIDs. The HashID mechanism
+      is not secure. By observing sufficient HashIDs, the salt used to construct
+      them can be recovered. This means the Flask secret key can be obtained by
+      attackers, through the HashIDs).
+note: >-
+  [CWE-327] Use of a Broken or Risky Cryptographic Algorithm.
+  [REFERENCES]
+      - https://flask.palletsprojects.com/en/2.2.x/config/#SECRET_KEY
+      - http://carnage.github.io/2015/08/cryptanalysis-of-hashids
+utils:
+  hashids.Hashids(..., salt=flask.current_app.config['SECRET_KEY'], ...):
+    # hashids.Hashids(..., salt=flask.current_app.config['SECRET_KEY'], ...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          regex: ^hashids.Hashids$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+             - has:
+                 stopBy: neighbor
+                 kind: identifier
+                 regex: ^salt$
+             - has:
+                 stopBy: neighbor
+                 kind: subscript
+                 pattern: flask.current_app.config['SECRET_KEY']
+  hashids.Hashids(flask.current_app.config['SECRET_KEY'], ...):
+    # hashids.Hashids(flask.current_app.config['SECRET_KEY'], ...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          regex: ^hashids.Hashids$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: neighbor
+            kind: subscript
+            pattern: flask.current_app.config['SECRET_KEY']
+  hashids.Hashids($APP.config['SECRET_KEY'], ...):
+    # hashids.Hashids($APP.config['SECRET_KEY'], ...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          regex: ^hashids.Hashids$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: neighbor
+            kind: subscript
+            pattern: $APP.config['SECRET_KEY']
+      - inside:
+          stopBy: end
+          kind: module
+          has:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: neighbor
+              kind: assignment
+              pattern: $APP = flask.Flask($$$)
+  hashids.Hashids(..., salt=$APP.config['SECRET_KEY'], ...):
+    # hashids.Hashids(..., salt=$APP.config['SECRET_KEY'], ...)
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: attribute
+          regex: ^hashids.Hashids$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+             - has:
+                 stopBy: neighbor
+                 kind: identifier
+                 regex: ^salt$
+             - has:
+                 stopBy: neighbor
+                 kind: subscript
+                 pattern: $APP.config['SECRET_KEY']
+      - inside:
+          stopBy: end
+          kind: module
+          has:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: neighbor
+              kind: assignment
+              pattern: $APP = flask.Flask($$$)
+  Hashids(salt=app.config['SECRET_KEY']):
+#    from hashids import Hashids
+#    from flask import current_app as app
+#    hash_id = Hashids(salt=app.config['SECRET_KEY'])
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: identifier
+          regex: ^Hashids$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+             - has:
+                 stopBy: neighbor
+                 kind: identifier
+                 regex: ^salt$
+             - has:
+                 stopBy: neighbor
+                 kind: subscript
+                 pattern: $APP.config['SECRET_KEY']
+      - inside:
+          stopBy: end
+          kind: module
+          all:
+            - has:
+                stopBy: end
+                kind: import_from_statement
+                pattern: from hashids import Hashids
+            - any:
+              - has:
+                 stopBy: end
+                 kind: import_from_statement
+                 pattern: from flask import current_app as $APP
+              - has:
+                  stopBy: end
+                  kind: expression_statement
+                  has:
+                    stopBy: end
+                    kind: assignment
+                    pattern: $APP = Flask($$$)
+  Hashids(salt=current_app.config['SECRET_KEY']):
+    # from hashids import Hashids
+    # from flask import current_app
+    # hashids = Hashids(min_length=5, salt=current_app.config['SECRET_KEY'])
+    kind: call
+    all:
+      - has:
+          stopBy: neighbor
+          kind: identifier
+          regex: ^Hashids$
+      - has:
+          stopBy: neighbor
+          kind: argument_list
+          has:
+            stopBy: end
+            kind: keyword_argument
+            all:
+             - has:
+                 stopBy: neighbor
+                 kind: identifier
+                 regex: ^salt$
+             - has:
+                 stopBy: neighbor
+                 kind: subscript
+                 pattern: current_app.config['SECRET_KEY']
+      - inside:
+          stopBy: end
+          kind: module
+          all:
+            - has:
+                stopBy: end
+                kind: import_from_statement
+                pattern: from hashids import Hashids
+            - has:
+                stopBy: end
+                kind: import_from_statement
+                pattern: from flask import current_app
+rule:
+ kind: call
+ any:
+   - matches: hashids.Hashids(..., salt=flask.current_app.config['SECRET_KEY'], ...)
+   - matches: hashids.Hashids(flask.current_app.config['SECRET_KEY'], ...)
+   - matches: hashids.Hashids($APP.config['SECRET_KEY'], ...)
+   - matches: hashids.Hashids(..., salt=$APP.config['SECRET_KEY'], ...)
+   - matches: Hashids(salt=app.config['SECRET_KEY'])
+   - matches: Hashids(salt=current_app.config['SECRET_KEY'])

--- a/rules/python/security/python-psycopg2-empty-password-python.yml
+++ b/rules/python/security/python-psycopg2-empty-password-python.yml
@@ -1,0 +1,89 @@
+id: python-psycopg2-empty-password-python
+severity: warning
+language: python
+message: >-
+      The application creates a database connection with an empty password.
+      This can lead to unauthorized access by either an internal or external
+      malicious actor. To prevent this vulnerability, enforce authentication
+      when connecting to a database by using environment variables to securely
+      provide credentials or retrieving them from a secure vault or HSM
+      (Hardware Security Module).
+note: >-
+  [CWE-287] Improper Authentication.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+utils:
+  psycopg2.connect(..., password="",...):
+   kind: call
+   all:
+     - has:
+         stopBy: neighbor
+         kind: attribute
+         regex: ^psycopg2.connect$
+     - has:
+         stopBy: neighbor
+         kind: argument_list
+         has:
+           stopBy: end
+           kind: keyword_argument
+           all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^password$
+            - has:
+                stopBy: neighbor
+                kind: string
+                not:
+                 has:
+                  stopBy: neighbor
+                  kind: string_content
+  psycopg2.connect(..., password=$VAR,...)_with_instance:
+   kind: call
+   all:
+     - has:
+         stopBy: neighbor
+         kind: attribute
+         regex: ^psycopg2.connect$
+     - has:
+         stopBy: neighbor
+         kind: argument_list
+         has:
+           stopBy: end
+           kind: keyword_argument
+           all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^password$
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                pattern: $PSWD
+                nthChild: 2
+     - inside:
+         stopBy: end
+         kind: expression_statement
+         follows:
+          stopBy: end
+          kind: expression_statement
+          has:
+            stopBy: neighbor
+            kind: assignment
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $PSWD
+              - has:
+                  stopBy: neighbor
+                  kind: string
+                  not:
+                    has:
+                      stopBy: neighbor
+                      kind: string_content
+rule:
+  kind: call
+  any:
+    - matches: psycopg2.connect(..., password="",...)
+    - matches: psycopg2.connect(..., password=$VAR,...)_with_instance

--- a/rules/python/security/python-urllib3-hardcoded-secret-python.yml
+++ b/rules/python/security/python-urllib3-hardcoded-secret-python.yml
@@ -1,0 +1,106 @@
+id: python-urllib3-hardcoded-secret-python
+severity: warning
+language: python
+message: >-
+      A secret is hard-coded in the application. Secrets stored in source
+      code, such as credentials, identifiers, and other types of sensitive data,
+      can be leaked and used by internal or external malicious actors. Use
+      environment variables to securely provide credentials and other secrets or
+      retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798] Use of Hard-coded Credentials.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+utils: 
+ urllib3.util.make_headers(...,basic_auth="...",...):
+  # urllib3.util.make_headers(...,basic_auth="...",...)
+  kind: call
+  all:
+    - has:
+        stopBy: neighbor
+        kind: attribute
+        regex: 'urllib3.util.make_headers|urllib3.make_headers|requests.packages.urllib3.make_headers|requests.packages.urllib3.util.make_headers'
+    - has:
+        stopBy: neighbor
+        kind: argument_list
+        has:
+          stopBy: end
+          kind: keyword_argument
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: '^basic_auth|proxy_basic_auth$'
+            - has:
+                stopBy: neighbor
+                kind: string
+                has:
+                  stopBy: neighbor
+                  kind: string_content
+ urllib3.util.make_headers(...,basic_auth="...",...)_with_instance:
+  # urllib3.util.make_headers(...,basic_auth="...",...)_with_instance
+  kind: call
+  all:
+    - has:
+        stopBy: neighbor
+        kind: attribute
+        regex: 'urllib3.util.make_headers|urllib3.make_headers|requests.packages.urllib3.make_headers|requests.packages.urllib3.util.make_headers'
+    - has:
+        stopBy: neighbor
+        kind: argument_list
+        has:
+          stopBy: end
+          kind: keyword_argument
+          all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: '^basic_auth|proxy_basic_auth$'
+            - has:
+                stopBy: end
+                kind: identifier
+                pattern: $PASS
+                nthChild: 2
+    - inside:
+        stopBy: end
+        kind: expression_statement
+        follows:
+          stopBy: end
+          kind: expression_statement
+          has:
+            stopBy: neighbor
+            kind: assignment
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $PASS
+              - has:
+                  stopBy: neighbor
+                  kind: string
+                  has:
+                    stopBy: neighbor
+                    kind: string_content
+    - inside:
+        stopBy: end
+        kind: expression_statement
+        not:
+         follows:
+          stopBy: end
+          kind: expression_statement
+          has:
+            stopBy: neighbor
+            kind: assignment
+            all:
+              - has:
+                  stopBy: neighbor
+                  kind: identifier
+                  pattern: $PASS
+              - has:
+                  stopBy: neighbor
+                  kind: subscript
+rule:
+  kind: call
+  any:
+    - matches: urllib3.util.make_headers(...,basic_auth="...",...)
+    - matches: urllib3.util.make_headers(...,basic_auth="...",...)_with_instance

--- a/tests/__snapshots__/hashids-with-flask-secret-python-snapshot.yml
+++ b/tests/__snapshots__/hashids-with-flask-secret-python-snapshot.yml
@@ -1,0 +1,230 @@
+id: hashids-with-flask-secret-python
+snapshots:
+  ? |
+    from hashids import Hashids
+    app = Flask(__name__.split('.')[0])
+    hashids = Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+  : labels:
+    - source: Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+      style: primary
+      start: 74
+      end: 126
+    - source: Hashids
+      style: secondary
+      start: 74
+      end: 81
+    - source: salt
+      style: secondary
+      start: 96
+      end: 100
+    - source: app.config['SECRET_KEY']
+      style: secondary
+      start: 101
+      end: 125
+    - source: salt=app.config['SECRET_KEY']
+      style: secondary
+      start: 96
+      end: 125
+    - source: (min_length=4, salt=app.config['SECRET_KEY'])
+      style: secondary
+      start: 81
+      end: 126
+    - source: from hashids import Hashids
+      style: secondary
+      start: 0
+      end: 27
+    - source: app = Flask(__name__.split('.')[0])
+      style: secondary
+      start: 28
+      end: 63
+    - source: app = Flask(__name__.split('.')[0])
+      style: secondary
+      start: 28
+      end: 63
+    - source: |
+        from hashids import Hashids
+        app = Flask(__name__.split('.')[0])
+        hashids = Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+      style: secondary
+      start: 0
+      end: 127
+  ? |
+    from hashids import Hashids
+    foo = Flask()
+    hashids = Hashids(min_length=4, salt=foo.config['SECRET_KEY'])
+  : labels:
+    - source: Hashids(min_length=4, salt=foo.config['SECRET_KEY'])
+      style: primary
+      start: 52
+      end: 104
+    - source: Hashids
+      style: secondary
+      start: 52
+      end: 59
+    - source: salt
+      style: secondary
+      start: 74
+      end: 78
+    - source: foo.config['SECRET_KEY']
+      style: secondary
+      start: 79
+      end: 103
+    - source: salt=foo.config['SECRET_KEY']
+      style: secondary
+      start: 74
+      end: 103
+    - source: (min_length=4, salt=foo.config['SECRET_KEY'])
+      style: secondary
+      start: 59
+      end: 104
+    - source: from hashids import Hashids
+      style: secondary
+      start: 0
+      end: 27
+    - source: foo = Flask()
+      style: secondary
+      start: 28
+      end: 41
+    - source: foo = Flask()
+      style: secondary
+      start: 28
+      end: 41
+    - source: |
+        from hashids import Hashids
+        foo = Flask()
+        hashids = Hashids(min_length=4, salt=foo.config['SECRET_KEY'])
+      style: secondary
+      start: 0
+      end: 105
+  ? |
+    from hashids import Hashids
+    from flask import current_app
+    hashids = Hashids(min_length=5, salt=current_app.config['SECRET_KEY'])
+  : labels:
+    - source: Hashids(min_length=5, salt=current_app.config['SECRET_KEY'])
+      style: primary
+      start: 68
+      end: 128
+    - source: Hashids
+      style: secondary
+      start: 68
+      end: 75
+    - source: salt
+      style: secondary
+      start: 90
+      end: 94
+    - source: current_app.config['SECRET_KEY']
+      style: secondary
+      start: 95
+      end: 127
+    - source: salt=current_app.config['SECRET_KEY']
+      style: secondary
+      start: 90
+      end: 127
+    - source: (min_length=5, salt=current_app.config['SECRET_KEY'])
+      style: secondary
+      start: 75
+      end: 128
+    - source: from hashids import Hashids
+      style: secondary
+      start: 0
+      end: 27
+    - source: from flask import current_app
+      style: secondary
+      start: 28
+      end: 57
+    - source: |
+        from hashids import Hashids
+        from flask import current_app
+        hashids = Hashids(min_length=5, salt=current_app.config['SECRET_KEY'])
+      style: secondary
+      start: 0
+      end: 129
+  ? |
+    from hashids import Hashids
+    from flask import current_app as app
+    hash_id = Hashids(salt=app.config['SECRET_KEY'], min_length=34)
+  : labels:
+    - source: Hashids(salt=app.config['SECRET_KEY'], min_length=34)
+      style: primary
+      start: 75
+      end: 128
+    - source: Hashids
+      style: secondary
+      start: 75
+      end: 82
+    - source: salt
+      style: secondary
+      start: 83
+      end: 87
+    - source: app.config['SECRET_KEY']
+      style: secondary
+      start: 88
+      end: 112
+    - source: salt=app.config['SECRET_KEY']
+      style: secondary
+      start: 83
+      end: 112
+    - source: (salt=app.config['SECRET_KEY'], min_length=34)
+      style: secondary
+      start: 82
+      end: 128
+    - source: from hashids import Hashids
+      style: secondary
+      start: 0
+      end: 27
+    - source: from flask import current_app as app
+      style: secondary
+      start: 28
+      end: 64
+    - source: |
+        from hashids import Hashids
+        from flask import current_app as app
+        hash_id = Hashids(salt=app.config['SECRET_KEY'], min_length=34)
+      style: secondary
+      start: 0
+      end: 129
+  ? |
+    from hashids import Hashids
+    from flask import current_app as app
+    hashids = Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+  : labels:
+    - source: Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+      style: primary
+      start: 75
+      end: 127
+    - source: Hashids
+      style: secondary
+      start: 75
+      end: 82
+    - source: salt
+      style: secondary
+      start: 97
+      end: 101
+    - source: app.config['SECRET_KEY']
+      style: secondary
+      start: 102
+      end: 126
+    - source: salt=app.config['SECRET_KEY']
+      style: secondary
+      start: 97
+      end: 126
+    - source: (min_length=4, salt=app.config['SECRET_KEY'])
+      style: secondary
+      start: 82
+      end: 127
+    - source: from hashids import Hashids
+      style: secondary
+      start: 0
+      end: 27
+    - source: from flask import current_app as app
+      style: secondary
+      start: 28
+      end: 64
+    - source: |
+        from hashids import Hashids
+        from flask import current_app as app
+        hashids = Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+      style: secondary
+      start: 0
+      end: 128

--- a/tests/__snapshots__/python-psycopg2-empty-password-python-snapshot.yml
+++ b/tests/__snapshots__/python-psycopg2-empty-password-python-snapshot.yml
@@ -1,0 +1,77 @@
+id: python-psycopg2-empty-password-python
+snapshots:
+  ? |
+    PASSWORD = ""
+    psycopg2.connect(password=PASSWORD)
+  : labels:
+    - source: psycopg2.connect(password=PASSWORD)
+      style: primary
+      start: 14
+      end: 49
+    - source: psycopg2.connect
+      style: secondary
+      start: 14
+      end: 30
+    - source: password
+      style: secondary
+      start: 31
+      end: 39
+    - source: PASSWORD
+      style: secondary
+      start: 40
+      end: 48
+    - source: password=PASSWORD
+      style: secondary
+      start: 31
+      end: 48
+    - source: (password=PASSWORD)
+      style: secondary
+      start: 30
+      end: 49
+    - source: PASSWORD
+      style: secondary
+      start: 0
+      end: 8
+    - source: '""'
+      style: secondary
+      start: 11
+      end: 13
+    - source: PASSWORD = ""
+      style: secondary
+      start: 0
+      end: 13
+    - source: PASSWORD = ""
+      style: secondary
+      start: 0
+      end: 13
+    - source: psycopg2.connect(password=PASSWORD)
+      style: secondary
+      start: 14
+      end: 49
+  ? |
+    psycopg2.connect(password="")
+  : labels:
+    - source: psycopg2.connect(password="")
+      style: primary
+      start: 0
+      end: 29
+    - source: psycopg2.connect
+      style: secondary
+      start: 0
+      end: 16
+    - source: password
+      style: secondary
+      start: 17
+      end: 25
+    - source: '""'
+      style: secondary
+      start: 26
+      end: 28
+    - source: password=""
+      style: secondary
+      start: 17
+      end: 28
+    - source: (password="")
+      style: secondary
+      start: 16
+      end: 29

--- a/tests/__snapshots__/python-urllib3-hardcoded-secret-python-snapshot.yml
+++ b/tests/__snapshots__/python-urllib3-hardcoded-secret-python-snapshot.yml
@@ -1,0 +1,238 @@
+id: python-urllib3-hardcoded-secret-python
+snapshots:
+  ? |
+    auth_str = 'user:123'
+    headers = requests.packages.urllib3.make_headers(basic_auth=auth_str)
+  : labels:
+    - source: requests.packages.urllib3.make_headers(basic_auth=auth_str)
+      style: primary
+      start: 32
+      end: 91
+    - source: requests.packages.urllib3.make_headers
+      style: secondary
+      start: 32
+      end: 70
+    - source: basic_auth
+      style: secondary
+      start: 71
+      end: 81
+    - source: auth_str
+      style: secondary
+      start: 82
+      end: 90
+    - source: basic_auth=auth_str
+      style: secondary
+      start: 71
+      end: 90
+    - source: (basic_auth=auth_str)
+      style: secondary
+      start: 70
+      end: 91
+    - source: auth_str
+      style: secondary
+      start: 0
+      end: 8
+    - source: user:123
+      style: secondary
+      start: 12
+      end: 20
+    - source: '''user:123'''
+      style: secondary
+      start: 11
+      end: 21
+    - source: auth_str = 'user:123'
+      style: secondary
+      start: 0
+      end: 21
+    - source: auth_str = 'user:123'
+      style: secondary
+      start: 0
+      end: 21
+    - source: headers = requests.packages.urllib3.make_headers(basic_auth=auth_str)
+      style: secondary
+      start: 22
+      end: 91
+    - source: headers = requests.packages.urllib3.make_headers(basic_auth=auth_str)
+      style: secondary
+      start: 22
+      end: 91
+  ? |
+    headers = requests.packages.urllib3.util.make_headers(basic_auth='pass')
+  : labels:
+    - source: requests.packages.urllib3.util.make_headers(basic_auth='pass')
+      style: primary
+      start: 10
+      end: 72
+    - source: requests.packages.urllib3.util.make_headers
+      style: secondary
+      start: 10
+      end: 53
+    - source: basic_auth
+      style: secondary
+      start: 54
+      end: 64
+    - source: pass
+      style: secondary
+      start: 66
+      end: 70
+    - source: '''pass'''
+      style: secondary
+      start: 65
+      end: 71
+    - source: basic_auth='pass'
+      style: secondary
+      start: 54
+      end: 71
+    - source: (basic_auth='pass')
+      style: secondary
+      start: 53
+      end: 72
+  ? |
+    password = '123'
+    headers = urllib3.util.make_headers(proxy_basic_auth=user + ':' + password)
+  : labels:
+    - source: urllib3.util.make_headers(proxy_basic_auth=user + ':' + password)
+      style: primary
+      start: 27
+      end: 92
+    - source: urllib3.util.make_headers
+      style: secondary
+      start: 27
+      end: 52
+    - source: proxy_basic_auth
+      style: secondary
+      start: 53
+      end: 69
+    - source: password
+      style: secondary
+      start: 83
+      end: 91
+    - source: proxy_basic_auth=user + ':' + password
+      style: secondary
+      start: 53
+      end: 91
+    - source: (proxy_basic_auth=user + ':' + password)
+      style: secondary
+      start: 52
+      end: 92
+    - source: password
+      style: secondary
+      start: 0
+      end: 8
+    - source: '123'
+      style: secondary
+      start: 12
+      end: 15
+    - source: '''123'''
+      style: secondary
+      start: 11
+      end: 16
+    - source: password = '123'
+      style: secondary
+      start: 0
+      end: 16
+    - source: password = '123'
+      style: secondary
+      start: 0
+      end: 16
+    - source: headers = urllib3.util.make_headers(proxy_basic_auth=user + ':' + password)
+      style: secondary
+      start: 17
+      end: 92
+    - source: headers = urllib3.util.make_headers(proxy_basic_auth=user + ':' + password)
+      style: secondary
+      start: 17
+      end: 92
+  ? |
+    urllib3.make_headers(basic_auth="user:123")
+  : labels:
+    - source: urllib3.make_headers(basic_auth="user:123")
+      style: primary
+      start: 0
+      end: 43
+    - source: urllib3.make_headers
+      style: secondary
+      start: 0
+      end: 20
+    - source: basic_auth
+      style: secondary
+      start: 21
+      end: 31
+    - source: user:123
+      style: secondary
+      start: 33
+      end: 41
+    - source: '"user:123"'
+      style: secondary
+      start: 32
+      end: 42
+    - source: basic_auth="user:123"
+      style: secondary
+      start: 21
+      end: 42
+    - source: (basic_auth="user:123")
+      style: secondary
+      start: 20
+      end: 43
+  ? |
+    urllib3.util.make_headers(basic_auth="user:123")
+  : labels:
+    - source: urllib3.util.make_headers(basic_auth="user:123")
+      style: primary
+      start: 0
+      end: 48
+    - source: urllib3.util.make_headers
+      style: secondary
+      start: 0
+      end: 25
+    - source: basic_auth
+      style: secondary
+      start: 26
+      end: 36
+    - source: user:123
+      style: secondary
+      start: 38
+      end: 46
+    - source: '"user:123"'
+      style: secondary
+      start: 37
+      end: 47
+    - source: basic_auth="user:123"
+      style: secondary
+      start: 26
+      end: 47
+    - source: (basic_auth="user:123")
+      style: secondary
+      start: 25
+      end: 48
+  ? |
+    urllib3.util.make_headers(proxy_basic_auth="user:123")
+  : labels:
+    - source: urllib3.util.make_headers(proxy_basic_auth="user:123")
+      style: primary
+      start: 0
+      end: 54
+    - source: urllib3.util.make_headers
+      style: secondary
+      start: 0
+      end: 25
+    - source: proxy_basic_auth
+      style: secondary
+      start: 26
+      end: 42
+    - source: user:123
+      style: secondary
+      start: 44
+      end: 52
+    - source: '"user:123"'
+      style: secondary
+      start: 43
+      end: 53
+    - source: proxy_basic_auth="user:123"
+      style: secondary
+      start: 26
+      end: 53
+    - source: (proxy_basic_auth="user:123")
+      style: secondary
+      start: 25
+      end: 54

--- a/tests/python/hashids-with-flask-secret-python-test.yml
+++ b/tests/python/hashids-with-flask-secret-python-test.yml
@@ -1,0 +1,25 @@
+id: hashids-with-flask-secret-python
+valid:
+  - |
+    hashids = Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+invalid:
+  - |
+    from hashids import Hashids
+    from flask import current_app as app
+    hash_id = Hashids(salt=app.config['SECRET_KEY'], min_length=34)
+  - |
+    from hashids import Hashids
+    from flask import current_app as app
+    hashids = Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+  - |
+    from hashids import Hashids
+    from flask import current_app
+    hashids = Hashids(min_length=5, salt=current_app.config['SECRET_KEY'])
+  - |
+    from hashids import Hashids
+    foo = Flask()
+    hashids = Hashids(min_length=4, salt=foo.config['SECRET_KEY'])
+  - |
+    from hashids import Hashids
+    app = Flask(__name__.split('.')[0])
+    hashids = Hashids(min_length=4, salt=app.config['SECRET_KEY'])

--- a/tests/python/python-psycopg2-empty-password-python-test.yml
+++ b/tests/python/python-psycopg2-empty-password-python-test.yml
@@ -1,0 +1,10 @@
+id: python-psycopg2-empty-password-python
+valid:
+  - |
+    psycopg2.connect(password="password")
+invalid:
+  - |
+    psycopg2.connect(password="")
+  - |
+    PASSWORD = ""
+    psycopg2.connect(password=PASSWORD)

--- a/tests/python/python-urllib3-hardcoded-secret-python-test.yml
+++ b/tests/python/python-urllib3-hardcoded-secret-python-test.yml
@@ -1,0 +1,19 @@
+id: python-urllib3-hardcoded-secret-python
+valid:
+  - |
+    urllib3.util.make_headers(basic_auth=user:123)
+invalid:
+  - |
+    urllib3.util.make_headers(basic_auth="user:123")
+  - |
+    urllib3.util.make_headers(proxy_basic_auth="user:123")
+  - |
+    urllib3.make_headers(basic_auth="user:123")
+  - |
+    headers = requests.packages.urllib3.util.make_headers(basic_auth='pass')
+  - |  
+    password = '123'
+    headers = urllib3.util.make_headers(proxy_basic_auth=user + ':' + password)
+  - | 
+    auth_str = 'user:123'
+    headers = requests.packages.urllib3.make_headers(basic_auth=auth_str)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new security rules for detecting insecure practices in Python applications:
		- `hashids-with-flask-secret-python`: Flags use of Flask secret key as salt in HashIDs.
		- `python-psycopg2-empty-password-python`: Warns against using empty passwords in database connections.
		- `python-urllib3-hardcoded-secret-python`: Identifies hard-coded secrets in HTTP headers.

- **Tests**
	- Added test configurations and snapshots for validating the new security rules and their behaviors in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->