### PR TITLE
Add Security Rules for Weak Cryptographic Algorithms and Insecure SSL

### DIFF
--- a/rules/java/security/use-of-md5-java.yml
+++ b/rules/java/security/use-of-md5-java.yml
@@ -1,0 +1,20 @@
+id: use-of-md5-java
+severity: warning
+language: java
+message: >-
+  Detected MD5 hash algorithm which is considered insecure. MD5 is not
+  collision resistant and is therefore not suitable as a cryptographic
+  signature. Use HMAC instead.
+note: >-
+  [CWE-328] Use of Weak Hash.
+  [REFERENCES]
+      - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+rule:
+  any:
+    - pattern: java.security.MessageDigest.getInstance($ALGO)
+    - pattern: java.security.MessageDigest.getInstance($ALGO, $$$)
+    - pattern: MessageDigest.getInstance($ALGO)
+    - pattern: MessageDigest.getInstance($ALGO, $$$)
+constraints:
+  ALGO:
+    regex: 'MD5'

--- a/rules/java/security/use-of-sha1-java.yml
+++ b/rules/java/security/use-of-sha1-java.yml
@@ -1,0 +1,23 @@
+id: use-of-sha1-java
+language: java
+severity: warning
+message: >-
+  Detected SHA1 hash algorithm which is considered insecure. SHA1 is not
+  collision resistant and is therefore not suitable as a cryptographic
+  signature. Instead, use PBKDF2 for password hashing or SHA256 or SHA512
+  for other hash function applications.
+note: >-
+  [CWE-328] Use of Weak Hash.
+  [REFERENCES]
+      - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+rule:
+  any:
+  - pattern: $DU.getSha1Digest().digest($$$)
+  - pattern: MessageDigest.getInstance($ALGO)
+  - pattern: MessageDigest.getInstance($ALGO,$$$)
+  - pattern: java.security.MessageDigest.getInstance($ALGO,$$$)
+constraints:
+  ALGO:
+    regex: 'SHA1|SHA-1'
+
+

--- a/rules/java/security/weak-ssl-context-java.yml
+++ b/rules/java/security/weak-ssl-context-java.yml
@@ -1,0 +1,75 @@
+id: weak-ssl-context-java
+language: java
+severity: warning
+message: >-
+  'An insecure SSL context was detected. TLS versions 1.0, 1.1, and all
+      SSL versions are considered weak encryption and are deprecated. Use
+      SSLContext.getInstance("TLSv1.2") for the best security.'
+note: >-
+  [CWE-326] Inadequate Encryption Strength
+  [REFERENCES]
+      - https://tools.ietf.org/html/rfc7568
+      - https://tools.ietf.org/id/draft-ietf-tls-oldversions-deprecate-02.html
+
+rule:
+  all:
+    - pattern: SSLContext.getInstance($CONTEXT)
+    - not:
+        pattern: SSLContext.getInstance("TLSv1.3")
+    - not:
+        pattern: SSLContext.getInstance("TLSv1.2")
+constraints:
+  CONTEXT:
+    any:
+      - kind: string_literal
+        pattern: $TLS
+        not:
+          regex: ^['"`](TLSv1.2|TLSv1.3)['"`]$
+      - kind: identifier
+        inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - kind: local_variable_declaration
+              - kind: field_declaration
+            all:
+              - has:
+                  kind: type_identifier
+                  regex: ^String$
+              - has:
+                  stopBy: end
+                  kind: variable_declarator
+                  all:
+                    - has:
+                        kind: identifier
+                        stopBy: end
+                        pattern: $CONTEXT
+                    - has:
+                        kind: string_literal
+                        pattern: $TLS
+                        not:
+                          regex: ^['"`](TLSv1.2|TLSv1.3)['"`]$
+      - kind: identifier
+        follows:
+          stopBy: end
+          any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+          all:
+            - has:
+                kind: type_identifier
+                regex: ^String$
+            - has:
+                stopBy: end
+                kind: variable_declarator
+                all:
+                  - has:
+                      kind: identifier
+                      stopBy: end
+                      pattern: $CONTEXT
+                  - has:
+                      kind: string_literal
+                      pattern: $TLS
+                      not:
+                        regex: ^['"`](TLSv1.2|TLSv1.3)['"`]$

--- a/tests/__snapshots__/use-of-md5-java-snapshot.yml
+++ b/tests/__snapshots__/use-of-md5-java-snapshot.yml
@@ -1,0 +1,9 @@
+id: use-of-md5-java
+snapshots:
+  ? |
+    MessageDigest md5Digest = MessageDigest.getInstance("MD5");
+  : labels:
+    - source: MessageDigest.getInstance("MD5")
+      style: primary
+      start: 26
+      end: 58

--- a/tests/__snapshots__/use-of-sha1-java-snapshot.yml
+++ b/tests/__snapshots__/use-of-sha1-java-snapshot.yml
@@ -1,0 +1,31 @@
+id: use-of-sha1-java
+snapshots:
+  ? |
+    MessageDigest sha1Digest = MessageDigest.getInstance("SHA1");
+  : labels:
+    - source: MessageDigest.getInstance("SHA1")
+      style: primary
+      start: 27
+      end: 60
+  ? |
+    MessageDigest sha1Digest = MessageDigest.getInstance("SHA1", "SUN");
+  : labels:
+    - source: MessageDigest.getInstance("SHA1", "SUN")
+      style: primary
+      start: 27
+      end: 67
+  ? |
+    byte[] hashValue = DigestUtils.getSha1Digest().digest(password.getBytes());
+  : labels:
+    - source: DigestUtils.getSha1Digest().digest(password.getBytes())
+      style: primary
+      start: 19
+      end: 74
+  ? |
+    java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA1", "SUN");
+    DigestUtils.getSha1Digest().digest(password.getBytes());
+  : labels:
+    - source: java.security.MessageDigest.getInstance("SHA1", "SUN")
+      style: primary
+      start: 33
+      end: 87

--- a/tests/__snapshots__/weak-ssl-context-java-snapshot.yml
+++ b/tests/__snapshots__/weak-ssl-context-java-snapshot.yml
@@ -1,0 +1,37 @@
+id: weak-ssl-context-java
+snapshots:
+  ? |
+    SSLContext ctx = SSLContext.getInstance("SSL");
+  : labels:
+    - source: SSLContext.getInstance("SSL")
+      style: primary
+      start: 17
+      end: 46
+  ? |
+    SSLContext ctx = SSLContext.getInstance("SSLv3");
+  : labels:
+    - source: SSLContext.getInstance("SSLv3")
+      style: primary
+      start: 17
+      end: 48
+  ? |
+    SSLContext ctx = SSLContext.getInstance("TLS");
+  : labels:
+    - source: SSLContext.getInstance("TLS")
+      style: primary
+      start: 17
+      end: 46
+  ? |
+    SSLContext ctx = SSLContext.getInstance("TLSv1");
+  : labels:
+    - source: SSLContext.getInstance("TLSv1")
+      style: primary
+      start: 17
+      end: 48
+  ? |
+    SSLContext ctx = SSLContext.getInstance("TLSv1.1");
+  : labels:
+    - source: SSLContext.getInstance("TLSv1.1")
+      style: primary
+      start: 17
+      end: 50

--- a/tests/java/use-of-md5-java-test.yml
+++ b/tests/java/use-of-md5-java-test.yml
@@ -1,0 +1,7 @@
+id: use-of-md5-java
+valid:
+  - |
+    MessageDigest md5Digest = MessageDigest.getInstance("SHA-512");
+invalid:
+  - |
+    MessageDigest md5Digest = MessageDigest.getInstance("MD5");

--- a/tests/java/use-of-sha1-java-test.yml
+++ b/tests/java/use-of-sha1-java-test.yml
@@ -1,0 +1,18 @@
+id: use-of-sha1-java
+valid:
+  - |
+    java.io.File fileTarget = new java.io.File(
+    new java.io.File(org.owasp.benchmark.helpers.Utils.TESTFILES_DIR),
+    "passwordFile.txt");
+invalid:
+  - |
+    java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA1", "SUN");
+    DigestUtils.getSha1Digest().digest(password.getBytes());
+  - |
+    MessageDigest sha1Digest = MessageDigest.getInstance("SHA1", "SUN");
+  - |
+    byte[] hashValue = DigestUtils.getSha1Digest().digest(password.getBytes());
+  - |
+    MessageDigest sha1Digest = MessageDigest.getInstance("SHA1");
+  - |
+    byte[] hashValue = DigestUtils.getSha1Digest().digest(password.getBytes());

--- a/tests/java/weak-ssl-context-java-test.yml
+++ b/tests/java/weak-ssl-context-java-test.yml
@@ -1,0 +1,19 @@
+id: weak-ssl-context-java
+valid:
+  - |
+    SSLContext ctx = SSLContext.getInstance("TLSv1.2");
+  - |
+    SSLContext ctx = SSLContext.getInstance("TLSv1.3");
+  - |
+    SSLContext ctx = SSLContext.getInstance(getSslContext());
+invalid:
+  - |
+    SSLContext ctx = SSLContext.getInstance("SSL");
+  - |
+    SSLContext ctx = SSLContext.getInstance("TLS");
+  - |
+    SSLContext ctx = SSLContext.getInstance("TLSv1");
+  - |
+    SSLContext ctx = SSLContext.getInstance("SSLv3");
+  - |
+    SSLContext ctx = SSLContext.getInstance("TLSv1.1");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced rules to detect the use of insecure hashing algorithms (MD5, SHA-1) and weak SSL contexts in Java applications.
	- Added guidance for secure alternatives and references to security standards.
  
- **Tests**
	- Added test configurations to validate the usage of MD5 and SHA-1 algorithms, along with SSL context configurations.
	- Included valid and invalid examples to ensure adherence to secure practices. 

- **Snapshots**
	- Created snapshot entries for MD5, SHA-1, and weak SSL context usages to track instantiation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->