### PR TITLE
Add security rules for GCM nonce reuse and AES ECB mode detection in Java

### DIFF
--- a/rules/java/security/gcm-nonce-reuse-java.yml
+++ b/rules/java/security/gcm-nonce-reuse-java.yml
@@ -1,0 +1,18 @@
+id: gcm-nonce-reuse-java
+language: java
+severity: warning
+message: >-
+  GCM IV/nonce is reused: encryption can be totally useless.
+note: >-
+  [CWE-323] Reusing a Nonce, Key Pair in Encryption.
+  [REFERENCES]
+      - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+rule:
+  any:
+    - pattern: GCMParameterSpec $$$ = new GCMParameterSpec(GCM_TAG_LENGTH * 8, $A);
+      follows:
+        stopBy: end
+        pattern: byte[] $A = $_;
+    - pattern: new GCMParameterSpec($$$, "$$$".getBytes($$$), $$$)
+
+

--- a/rules/java/security/use-of-aes-ecb-java.yml
+++ b/rules/java/security/use-of-aes-ecb-java.yml
@@ -1,0 +1,30 @@
+id: use-of-aes-ecb-java
+language: java
+severity: warning
+message: >-
+    Use of AES with ECB mode detected. ECB doesn't provide message
+    confidentiality and  is not semantically secure so should not be used.
+    Instead, use a strong, secure cipher:
+    Cipher.getInstance(\"AES/CBC/PKCS7PADDING\"). See
+    https://owasp.org/www-community/Using_the_Java_Cryptographic_Extensions
+    for more information.
+note: >-
+  [CWE-327]: Use of a Broken or Risky Cryptographic Algorithm
+  [OWASP A03:2017]: Sensitive Data Exposure
+  [OWASP A02:2021]: Cryptographic Failures
+  [REFERENCES]
+      - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+      - https://googleprojectzero.blogspot.com/2022/10/rc4-is-still-considered-harmful.html
+utils:
+  match_method_invocation:
+    kind: method_invocation
+    has:
+      kind: argument_list
+      has:
+        kind: string_literal
+        regex: "AES/ECB"
+rule:
+  any:
+    - matches: match_method_invocation
+
+

--- a/tests/__snapshots__/gcm-nonce-reuse-java-snapshot.yml
+++ b/tests/__snapshots__/gcm-nonce-reuse-java-snapshot.yml
@@ -1,0 +1,14 @@
+id: gcm-nonce-reuse-java
+snapshots:
+  ? |
+    byte[] theBadIV = BAD_IV.getBytes();
+    GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theBadIV);
+  : labels:
+    - source: GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theBadIV);
+      style: primary
+      start: 37
+      end: 124
+    - source: byte[] theBadIV = BAD_IV.getBytes();
+      style: secondary
+      start: 0
+      end: 36

--- a/tests/__snapshots__/use-of-aes-ecb-java-snapshot.yml
+++ b/tests/__snapshots__/use-of-aes-ecb-java-snapshot.yml
@@ -1,0 +1,77 @@
+id: use-of-aes-ecb-java
+snapshots:
+  ? |
+    Cipher.getInstance("AES/ECB")
+  : labels:
+    - source: Cipher.getInstance("AES/ECB")
+      style: primary
+      start: 0
+      end: 29
+    - source: '"AES/ECB"'
+      style: secondary
+      start: 19
+      end: 28
+    - source: ("AES/ECB")
+      style: secondary
+      start: 18
+      end: 29
+  ? |
+    Cipher.getInstance("AES/ECB/ISO10126Padding")
+  : labels:
+    - source: Cipher.getInstance("AES/ECB/ISO10126Padding")
+      style: primary
+      start: 0
+      end: 45
+    - source: '"AES/ECB/ISO10126Padding"'
+      style: secondary
+      start: 19
+      end: 44
+    - source: ("AES/ECB/ISO10126Padding")
+      style: secondary
+      start: 18
+      end: 45
+  ? |
+    Cipher.getInstance("AES/ECB/NoPadding")
+  : labels:
+    - source: Cipher.getInstance("AES/ECB/NoPadding")
+      style: primary
+      start: 0
+      end: 39
+    - source: '"AES/ECB/NoPadding"'
+      style: secondary
+      start: 19
+      end: 38
+    - source: ("AES/ECB/NoPadding")
+      style: secondary
+      start: 18
+      end: 39
+  ? |
+    Cipher.getInstance("AES/ECB/PKCS5Padding")
+  : labels:
+    - source: Cipher.getInstance("AES/ECB/PKCS5Padding")
+      style: primary
+      start: 0
+      end: 42
+    - source: '"AES/ECB/PKCS5Padding"'
+      style: secondary
+      start: 19
+      end: 41
+    - source: ("AES/ECB/PKCS5Padding")
+      style: secondary
+      start: 18
+      end: 42
+  ? |
+    Cipher.getInstance("AES/ECB/PKCS7Padding")
+  : labels:
+    - source: Cipher.getInstance("AES/ECB/PKCS7Padding")
+      style: primary
+      start: 0
+      end: 42
+    - source: '"AES/ECB/PKCS7Padding"'
+      style: secondary
+      start: 19
+      end: 41
+    - source: ("AES/ECB/PKCS7Padding")
+      style: secondary
+      start: 18
+      end: 42

--- a/tests/java/gcm-nonce-reuse-java-test.yml
+++ b/tests/java/gcm-nonce-reuse-java-test.yml
@@ -1,0 +1,9 @@
+id: gcm-nonce-reuse-java
+valid:
+  - |
+    byte[] theBadIV = BAD_IV.getBytes();
+    GCMParameterSpec gcmParameter = new GCMParameter(GCM_TAG_LENGTH * 8, theBadIV);
+invalid:
+  - |
+    byte[] theBadIV = BAD_IV.getBytes();
+    GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theBadIV);

--- a/tests/java/use-of-aes-ecb-java-test.yml
+++ b/tests/java/use-of-aes-ecb-java-test.yml
@@ -1,0 +1,15 @@
+id: use-of-aes-ecb-java
+valid:
+  - |
+    Cipher.getInstance("AES/CBC/PKCS7PADDING")
+invalid:
+  - |
+    Cipher.getInstance("AES/ECB/NoPadding")
+  - |  
+    Cipher.getInstance("AES/ECB/PKCS5Padding")
+  - |  
+    Cipher.getInstance("AES/ECB/ISO10126Padding")
+  - |  
+    Cipher.getInstance("AES/ECB/PKCS7Padding")
+  - |  
+    Cipher.getInstance("AES/ECB")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a rule to detect potential GCM nonce reuse vulnerabilities in Java applications.
  - Added a rule to identify the use of AES in ECB mode, discouraging its use due to security concerns.
  
- **Tests**
  - Added test cases for GCM nonce reuse scenarios, including valid and invalid cases.
  - Implemented test cases for validating AES encryption modes, distinguishing valid CBC configurations from various invalid ECB configurations. 

- **Snapshots**
  - Created snapshots for GCM nonce reuse and various AES/ECB cipher configurations for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->