### PR TITLE
Add security rules for deprecated Triple DES and ECB mode detection

### DIFF
--- a/rules/java/security/desede-is-deprecated-java.yml
+++ b/rules/java/security/desede-is-deprecated-java.yml
@@ -1,0 +1,50 @@
+id: desede-is-deprecated-java
+language: java
+severity: warning
+message: >-
+    Triple DES (3DES or DESede) is considered deprecated. AES is the recommended cipher. Upgrade to use AES.
+note: >-
+  [CWE-326]: Inadequate Encryption Strength
+  [OWASP A03:2017]: Sensitive Data Exposure
+  [OWASP A02:2021]: Cryptographic Failures
+  [REFERENCES]
+      - https://find-sec-bugs.github.io/bugs.htm#TDES_USAGE
+      - https://csrc.nist.gov/News/2017/Update-to-Current-Use-and-Deprecation-of-TDEA
+utils:
+      match_method_invocation:
+            kind: method_invocation
+            all:
+                  - has:
+                        stopBy: end
+                        kind: identifier
+                  - has:
+                        stopBy: end
+                        kind: identifier
+                        regex: '^getInstance$'
+            has:
+                  stopBy: end
+                  kind: argument_list
+                  has:
+                        stopBy: end
+                        kind: string_literal
+                        regex: 'DESede'
+      match_key_generator:
+            kind: method_invocation
+            nthChild: 1
+            all:
+            - has:
+                  stopBy: end
+                  kind: field_access
+                  field: object
+            - has:
+                  stopBy: end
+                  kind: identifier
+                  regex: '^KeyGenerator$'
+rule:
+      any:
+            - matches: match_method_invocation
+            - matches: match_key_generator
+
+                     
+            
+

--- a/rules/java/security/ecb-cipher-java.yml
+++ b/rules/java/security/ecb-cipher-java.yml
@@ -1,0 +1,17 @@
+id: ecb-cipher-java
+severity: warning
+language: java
+message: >-
+      Cipher in ECB mode is detected. ECB mode produces the same output for
+      the same input each time which allows an attacker to intercept and replay
+      the data. Further, ECB mode does not provide any integrity checking. See
+      https://find-sec-bugs.github.io/bugs.htm#CIPHER_INTEGRITY.
+note: >-
+  [CWE-327] Use of a Broken or Risky Cryptographic Algorithm.
+  [REFERENCES]
+      - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+rule:
+  pattern: Cipher $VAR = $CIPHER.getInstance($MODE);
+constraints:
+  MODE:
+      regex: .*ECB.*

--- a/tests/__snapshots__/desede-is-deprecated-java-snapshot.yml
+++ b/tests/__snapshots__/desede-is-deprecated-java-snapshot.yml
@@ -1,0 +1,40 @@
+id: desede-is-deprecated-java
+snapshots:
+  ? |
+    Cipher c = Cipher.getInstance("kDESede/ECB/PKCS5Padding");
+    c.init(Cipher.ENCRYPT_MODE, k, iv);
+  : labels:
+    - source: Cipher.getInstance("kDESede/ECB/PKCS5Padding")
+      style: primary
+      start: 11
+      end: 57
+    - source: Cipher
+      style: secondary
+      start: 11
+      end: 17
+    - source: getInstance
+      style: secondary
+      start: 18
+      end: 29
+    - source: '"kDESede/ECB/PKCS5Padding"'
+      style: secondary
+      start: 30
+      end: 56
+    - source: ("kDESede/ECB/PKCS5Padding")
+      style: secondary
+      start: 29
+      end: 57
+  ? "javax.crypto.SecretKey key = javax.crypto.KeyGenerator.getInstance(\"DES\").generateKey();   \n"
+  : labels:
+    - source: javax.crypto.KeyGenerator.getInstance("DES")
+      style: primary
+      start: 29
+      end: 73
+    - source: javax.crypto.KeyGenerator
+      style: secondary
+      start: 29
+      end: 54
+    - source: KeyGenerator
+      style: secondary
+      start: 42
+      end: 54

--- a/tests/__snapshots__/ecb-cipher-java-snapshot.yml
+++ b/tests/__snapshots__/ecb-cipher-java-snapshot.yml
@@ -1,0 +1,9 @@
+id: ecb-cipher-java
+snapshots:
+  ? |
+    Cipher c = Cipher.getInstance("AES/ECB/NoPadding");
+  : labels:
+    - source: Cipher c = Cipher.getInstance("AES/ECB/NoPadding");
+      style: primary
+      start: 0
+      end: 51

--- a/tests/java/desede-is-deprecated-java-test.yml
+++ b/tests/java/desede-is-deprecated-java-test.yml
@@ -1,0 +1,10 @@
+id: desede-is-deprecated-java
+valid:
+  - |
+    Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
+invalid:
+  - |
+     Cipher c = Cipher.getInstance("kDESede/ECB/PKCS5Padding");
+     c.init(Cipher.ENCRYPT_MODE, k, iv);
+  - |
+    javax.crypto.SecretKey key = javax.crypto.KeyGenerator.getInstance("DES").generateKey();   

--- a/tests/java/ecb-cipher-java-test.yml
+++ b/tests/java/ecb-cipher-java-test.yml
@@ -1,0 +1,7 @@
+id: ecb-cipher-java
+valid:
+  - |
+    Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
+invalid:
+  - |
+    Cipher c = Cipher.getInstance("AES/ECB/NoPadding");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced rules to identify deprecated cryptographic practices in Java, specifically targeting Triple DES and ECB mode.
	- Added validation schemas for acceptable and unacceptable cryptographic algorithms.

- **Tests**
	- New test cases and snapshots added to validate the usage of cryptographic algorithms, including examples of valid and invalid cipher instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->