### PR TITLE
Add YAML security rules for static AES-CBC IV and debug logging in PHP

### DIFF
--- a/rules/php/security/openssl-cbc-static-iv-php.yml
+++ b/rules/php/security/openssl-cbc-static-iv-php.yml
@@ -1,0 +1,651 @@
+id: openssl-cbc-static-iv-php
+language: php
+severity: warning
+message: >-
+  Static IV used with AES in CBC mode. Static IVs enable chosen-plaintext
+  attacks against encrypted data.
+note: >-
+  [CWE-329] Generation of Predictable IV with CBC Mode.
+  [REFERENCES]
+      - https://csrc.nist.gov/publications/detail/sp/800-38a/final
+ast-grep-essentials: true
+utils:
+  Match_pattern_directly_with_prefix_openssl_encryptpart2:
+    kind: function_call_expression
+    all:
+      - has:
+            kind: name
+            regex: ^(openssl_decrypt|openssl_encrypt)$
+      - has:
+            stopBy: end
+            kind: arguments
+            all:
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 2
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: encapsed_string
+                   regex: ".*-CBC"
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 5
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: encapsed_string
+      - any:
+        - follows:
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+               stopBy: end
+               kind: variable_name
+               pattern: $T
+            - has:
+               stopBy: end
+               kind: encapsed_string
+        - inside:
+             stopBy: end
+             follows:
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $T
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+      - not:
+           inside:
+              stopBy: end
+              kind: conditional_expression
+
+  Match_pattern_with_prefix_openssl_encrypt:
+    kind: function_call_expression
+    all:
+      - not:
+           inside:
+              stopBy: end
+              kind: conditional_expression
+      - has:
+            kind: name
+            regex: ^(openssl_decrypt|openssl_encrypt)$
+      - has:
+            stopBy: end
+            kind: arguments
+            all:
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 2
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: variable_name
+                   pattern: $R
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 5
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: variable_name
+                   pattern: $T
+      - any:
+        - inside:
+             stopBy: end
+             follows:
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $T
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+        - follows:
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+               stopBy: end
+               kind: variable_name
+               pattern: $T
+            - has:
+               stopBy: end
+               kind: encapsed_string
+      - any:
+        - follows: 
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+                stopBy: end
+                kind: variable_name
+                pattern: $R
+            - has:
+                stopBy: end
+                kind: encapsed_string
+                regex: ".*-CBC"
+        - inside:
+             stopBy: end
+             follows: 
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $R
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+                  regex: ".*-CBC"
+
+  Match_pattern_with_prefix_openssl_decrypt:
+   kind: function_call_expression
+   all:
+      - not:
+           inside:
+              stopBy: end
+              kind: conditional_expression
+      - has:
+         kind: name
+         regex: ^(openssl_decrypt|openssl_encrypt)$
+      - has:
+            stopBy: end
+            kind: arguments
+            all:
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 2
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: variable_name
+                   pattern: $R
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 5
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: variable_name
+                   pattern: $T
+      - any:
+        - follows:
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+               stopBy: end
+               kind: variable_name
+               pattern: $T
+            - has:
+               stopBy: end
+               kind: encapsed_string
+        - inside:
+             stopBy: end
+             follows:
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $T
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+      - any:
+        - follows: 
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+                stopBy: end
+                kind: variable_name
+                pattern: $R
+            - has:
+                stopBy: end
+                kind: encapsed_string
+                regex: ".*-CBC"
+        - inside:
+             stopBy: end
+             follows: 
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $R
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+                  regex: ".*-CBC"
+
+  Match_pattern_directly_with_prefix_openssl_encrypt:
+    kind: function_call_expression
+    all:
+      - not:
+           inside:
+              stopBy: end
+              kind: conditional_expression
+      - has:
+            kind: name
+            regex: ^(openssl_decrypt|openssl_encrypt)$
+      - has:
+            stopBy: end
+            kind: arguments
+            all:
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 2
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: encapsed_string
+                   regex: ".*-CBC"
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 5
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: variable_name
+                   pattern: $T
+      - any:
+        - follows:
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+               stopBy: end
+               kind: variable_name
+               pattern: $T
+            - has:
+               stopBy: end
+               kind: encapsed_string
+        - inside:
+             stopBy: end
+             follows:
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $T
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+      
+  Match_pattern_directly_with_prefix_openssl_encrypt_return_statement:
+    kind: function_call_expression
+    all:
+      - not:
+           inside:
+              stopBy: end
+              kind: conditional_expression
+      - has:
+            kind: name
+            regex: ^(openssl_decrypt|openssl_encrypt)$
+      - has:
+            stopBy: end
+            kind: arguments
+            all:
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 2
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: encapsed_string
+                   regex: ".*-CBC"
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 5
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: variable_name
+                   pattern: $T
+      - any:
+        - inside:
+             stopBy: end
+             follows:
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $T
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+        - follows:
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+               stopBy: end
+               kind: variable_name
+               pattern: $T
+            - has:
+               stopBy: end
+               kind: encapsed_string
+   
+  Match_pattern_directly_with_prefix_openssl_encrypt_return_statement_(instance of cbc):
+    kind: function_call_expression
+    all:
+      - not:
+           inside:
+              stopBy: end
+              kind: conditional_expression
+      - has:
+            kind: name
+            regex: ^(openssl_decrypt|openssl_encrypt)$
+      - has:
+            stopBy: end
+            kind: arguments
+            all:
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 2
+                    pattern: $CBC
+                    ofRule:
+                       not:
+                          kind: comment
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 5
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: variable_name
+                   pattern: $T
+      - any:
+        - inside:
+             stopBy: end
+             follows:
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $T
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+        - follows:
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+               stopBy: end
+               kind: variable_name
+               pattern: $T
+            - has:
+               stopBy: end
+               kind: encapsed_string
+      - any:
+        - follows:
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+               stopBy: end
+               kind: variable_name
+               pattern: $CBC
+            - has:
+               stopBy: end
+               kind: encapsed_string
+               regex: "^.*-CBC"
+        - inside:
+             stopBy: end
+             follows:
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $CBC
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+                  regex: "^.*-CBC"
+
+  Match_pattern_with_prefix_openssl_encrypt_PART2:
+    kind: function_call_expression
+    all:
+      - not:
+           inside:
+              stopBy: end
+              kind: conditional_expression
+      - has:
+            kind: name
+            regex: ^(openssl_decrypt|openssl_encrypt)$
+      - has:
+            stopBy: end
+            kind: arguments
+            all:
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 2
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: variable_name
+                   pattern: $R
+              - has:
+                  stopBy: end
+                  kind: argument
+                  nthChild: 
+                    position: 5
+                    ofRule:
+                       not:
+                          kind: comment
+                  has:
+                   stopBy: end
+                   kind: encapsed_string
+      - any:
+        - inside:
+             stopBy: end
+             follows:
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $T
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+        - follows:
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+               stopBy: end
+               kind: variable_name
+               pattern: $T
+            - has:
+               stopBy: end
+               kind: encapsed_string
+      - any:
+        - follows: 
+           stopBy: end
+           kind: expression_statement
+           has:
+            stopBy: end
+            kind: assignment_expression
+            all:
+            - has:
+                stopBy: end
+                kind: variable_name
+                pattern: $R
+            - has:
+                stopBy: end
+                kind: encapsed_string
+                regex: ".*-CBC"
+        - inside:
+             stopBy: end
+             follows: 
+              stopBy: end
+              kind: expression_statement
+              has:
+               stopBy: end
+               kind: assignment_expression
+               all:
+               - has:
+                  stopBy: end
+                  kind: variable_name
+                  pattern: $R
+               - has:
+                  stopBy: end
+                  kind: encapsed_string
+                  regex: ".*-CBC"
+
+rule:
+  any:
+   - kind: function_call_expression
+     any:
+     - matches: Match_pattern_with_prefix_openssl_encrypt
+     - matches: Match_pattern_with_prefix_openssl_encrypt_PART2
+     - matches: Match_pattern_directly_with_prefix_openssl_encrypt
+     - matches: Match_pattern_directly_with_prefix_openssl_encryptpart2
+   - kind: return_statement
+     any:
+     - matches: Match_pattern_with_prefix_openssl_decrypt
+     - matches: Match_pattern_directly_with_prefix_openssl_encrypt_return_statement
+     - matches: Match_pattern_directly_with_prefix_openssl_encrypt_return_statement_(instance of cbc)
+  all:
+    - not:
+       has:
+        stopBy: end
+        kind: ERROR
+    - not:
+       inside:
+        stopBy: end
+        kind: ERROR

--- a/rules/php/security/search-active-debug-php.yml
+++ b/rules/php/security/search-active-debug-php.yml
@@ -1,0 +1,158 @@
+id: search-active-debug-php
+language: php
+severity: warning
+message: >-
+  Debug logging is explicitly enabled. This can potentially disclose
+  sensitive information and should never be active on production systems.
+note: >-
+  [CWE-489] Active Debug Code.
+  [REFERENCES]
+      - https://www.php.net/manual/en/function.setcookie.php
+ast-grep-essentials: true
+utils:
+  Match_pattern_one:
+    kind: function_call_expression
+    all:
+      - has:
+         pattern: $C
+      - has:
+         stopBy: end
+         kind: arguments
+         all:
+          - not:
+              has:
+                nthChild: 
+                  position: 3
+                  ofRule:
+                    not:
+                      kind: comment
+          - has:
+              stopBy: end
+              kind: argument
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: comment
+              has:
+               kind: encapsed_string
+               has:
+                 kind: string_content
+                 pattern: $A
+          - has:
+             kind: argument
+             nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: comment
+             has:
+              kind: boolean
+              pattern: $B
+              
+  Match_pattern_two_with_integer:
+    kind: function_call_expression
+    all:
+      - has:
+         pattern: $C
+      - has:
+         stopBy: end
+         kind: arguments
+         all:
+          - not:
+              has:
+                nthChild: 
+                  position: 3
+                  ofRule:
+                    not:
+                      kind: comment
+          - has:
+              stopBy: end
+              kind: argument
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: comment
+              has:
+               kind: encapsed_string
+               has:
+                 kind: string_content
+                 pattern: $A
+          - has:
+             kind: argument
+             nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: comment
+             has:
+              kind: integer
+              pattern: $D
+
+  Match_pattern_three_with_string:
+    kind: function_call_expression
+    all:
+      - has:
+         pattern: $C
+      - has:
+         kind: arguments
+         all:
+          - not:
+              has:
+                nthChild: 
+                  position: 3
+                  ofRule:
+                    not:
+                      kind: comment
+          - has:
+              stopBy: end
+              kind: argument
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: comment
+              has:
+               kind: encapsed_string
+               has:
+                 kind: string_content
+                 pattern: $A
+          - has:
+              stopBy: end
+              kind: argument
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: comment
+              has:
+                stopBy: end
+                kind: encapsed_string
+                has:
+                  stopBy: neighbor
+                  regex: ^[Oo][Nn]$
+                  
+rule:
+  any:
+    - matches: Match_pattern_one
+    - matches: Match_pattern_two_with_integer
+    - matches: Match_pattern_three_with_string
+  not:
+    all:
+      - has:
+          stopBy: end
+          kind: ERROR
+      - inside:
+          stopBy: end
+          kind: ERROR
+          
+constraints:
+  C:
+    regex: ^(define|ini_set)$
+  A:
+    regex: ^(WP_DEBUG|display_errors)$
+  B:
+    regex: ^([tT][Rr][Uu][Ee])$
+  D:
+    regex: ^1$

--- a/tests/__snapshots__/openssl-cbc-static-iv-php-snapshot.yml
+++ b/tests/__snapshots__/openssl-cbc-static-iv-php-snapshot.yml
@@ -1,0 +1,357 @@
+id: openssl-cbc-static-iv-php
+snapshots:
+  ? |
+    <?php
+    function decryptBad3($ivHashCiphertext, $password) {
+    $method = "AES-256-CBC";
+    $iv = "1234567890abcdef"; // Static IV
+    $hash = substr($ivHashCiphertext, 16, 32);
+    $ciphertext = substr($ivHashCiphertext, 48);
+    $key = hash('sha256', $password, true);
+    if (!hash_equals(hash_hmac('sha256', $ciphertext . $iv, $key, true), $hash)) return null;
+    return openssl_decrypt($ciphertext, $method, $key, OPENSSL_RAW_DATA, $iv);
+    }
+  : labels:
+    - source: openssl_decrypt($ciphertext, $method, $key, OPENSSL_RAW_DATA, $iv)
+      style: primary
+      start: 348
+      end: 414
+    - source: openssl_decrypt
+      style: secondary
+      start: 348
+      end: 363
+    - source: $method
+      style: secondary
+      start: 377
+      end: 384
+    - source: $method
+      style: secondary
+      start: 377
+      end: 384
+    - source: $iv
+      style: secondary
+      start: 410
+      end: 413
+    - source: $iv
+      style: secondary
+      start: 410
+      end: 413
+    - source: ($ciphertext, $method, $key, OPENSSL_RAW_DATA, $iv)
+      style: secondary
+      start: 363
+      end: 414
+    - source: $iv
+      style: secondary
+      start: 84
+      end: 87
+    - source: '"1234567890abcdef"'
+      style: secondary
+      start: 90
+      end: 108
+    - source: $iv = "1234567890abcdef"
+      style: secondary
+      start: 84
+      end: 108
+    - source: $iv = "1234567890abcdef";
+      style: secondary
+      start: 84
+      end: 109
+    - source: $iv = "1234567890abcdef";
+      style: secondary
+      start: 84
+      end: 109
+    - source: $method
+      style: secondary
+      start: 59
+      end: 66
+    - source: '"AES-256-CBC"'
+      style: secondary
+      start: 69
+      end: 82
+    - source: $method = "AES-256-CBC"
+      style: secondary
+      start: 59
+      end: 82
+    - source: $method = "AES-256-CBC";
+      style: secondary
+      start: 59
+      end: 83
+    - source: $method = "AES-256-CBC";
+      style: secondary
+      start: 59
+      end: 83
+  ? |
+    <?php
+    function decryptBad4($ivHashCiphertext, $password) {
+    $iv = "abcdef1234567890"; // Static IV
+    $hash = substr($ivHashCiphertext, 16, 32);
+    $ciphertext = substr($ivHashCiphertext, 48);
+    $key = hash('sha256', $password, true);
+    if (!hash_equals(hash_hmac('sha256', $ciphertext . $iv, $key, true), $hash)) return null;
+    return openssl_decrypt($ciphertext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv);
+    }
+  : labels:
+    - source: openssl_decrypt($ciphertext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv)
+      style: primary
+      start: 323
+      end: 395
+    - source: openssl_decrypt
+      style: secondary
+      start: 323
+      end: 338
+    - source: '"AES-256-CBC"'
+      style: secondary
+      start: 352
+      end: 365
+    - source: '"AES-256-CBC"'
+      style: secondary
+      start: 352
+      end: 365
+    - source: $iv
+      style: secondary
+      start: 391
+      end: 394
+    - source: $iv
+      style: secondary
+      start: 391
+      end: 394
+    - source: ($ciphertext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv)
+      style: secondary
+      start: 338
+      end: 395
+    - source: $iv
+      style: secondary
+      start: 59
+      end: 62
+    - source: '"abcdef1234567890"'
+      style: secondary
+      start: 65
+      end: 83
+    - source: $iv = "abcdef1234567890"
+      style: secondary
+      start: 59
+      end: 83
+    - source: $iv = "abcdef1234567890";
+      style: secondary
+      start: 59
+      end: 84
+    - source: $iv = "abcdef1234567890";
+      style: secondary
+      start: 59
+      end: 84
+  ? |
+    <?php
+    function encryptBad($plaintext, $password) {
+    $method = "AES-256-CBC";
+    $key = hash('sha256', $password, true);
+    $iv = "4c25ecc95c8816db753cba44a3b56aca";
+    $ciphertext = openssl_encrypt($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv);
+    $hash = hash_hmac('sha256', $ciphertext . $iv, $key, true);
+    return $iv . $hash . $ciphertext;
+    }
+  : labels:
+    - source: openssl_encrypt($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv)
+      style: primary
+      start: 172
+      end: 237
+    - source: openssl_encrypt
+      style: secondary
+      start: 172
+      end: 187
+    - source: $method
+      style: secondary
+      start: 200
+      end: 207
+    - source: $method
+      style: secondary
+      start: 200
+      end: 207
+    - source: $iv
+      style: secondary
+      start: 233
+      end: 236
+    - source: $iv
+      style: secondary
+      start: 233
+      end: 236
+    - source: ($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv)
+      style: secondary
+      start: 187
+      end: 237
+    - source: $iv
+      style: secondary
+      start: 116
+      end: 119
+    - source: '"4c25ecc95c8816db753cba44a3b56aca"'
+      style: secondary
+      start: 122
+      end: 156
+    - source: $iv = "4c25ecc95c8816db753cba44a3b56aca"
+      style: secondary
+      start: 116
+      end: 156
+    - source: $iv = "4c25ecc95c8816db753cba44a3b56aca";
+      style: secondary
+      start: 116
+      end: 157
+    - source: $iv = "4c25ecc95c8816db753cba44a3b56aca";
+      style: secondary
+      start: 116
+      end: 157
+    - source: $method
+      style: secondary
+      start: 51
+      end: 58
+    - source: '"AES-256-CBC"'
+      style: secondary
+      start: 61
+      end: 74
+    - source: $method = "AES-256-CBC"
+      style: secondary
+      start: 51
+      end: 74
+    - source: $method = "AES-256-CBC";
+      style: secondary
+      start: 51
+      end: 75
+    - source: $method = "AES-256-CBC";
+      style: secondary
+      start: 51
+      end: 75
+  ? |
+    <?php
+    function encryptBad3($plaintext, $password) {
+    $method = "AES-256-CBC";
+    $key = hash('sha256', $password, true);
+    $iv = "1234567890abcdef"; // Static IV
+    $ciphertext = openssl_encrypt($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv);
+    $hash = hash_hmac('sha256', $ciphertext . $iv, $key, true);
+    return $iv . $hash . $ciphertext;
+    }
+  : labels:
+    - source: openssl_encrypt($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv)
+      style: primary
+      start: 170
+      end: 235
+    - source: openssl_encrypt
+      style: secondary
+      start: 170
+      end: 185
+    - source: $method
+      style: secondary
+      start: 198
+      end: 205
+    - source: $method
+      style: secondary
+      start: 198
+      end: 205
+    - source: $iv
+      style: secondary
+      start: 231
+      end: 234
+    - source: $iv
+      style: secondary
+      start: 231
+      end: 234
+    - source: ($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv)
+      style: secondary
+      start: 185
+      end: 235
+    - source: $iv
+      style: secondary
+      start: 117
+      end: 120
+    - source: '"1234567890abcdef"'
+      style: secondary
+      start: 123
+      end: 141
+    - source: $iv = "1234567890abcdef"
+      style: secondary
+      start: 117
+      end: 141
+    - source: $iv = "1234567890abcdef";
+      style: secondary
+      start: 117
+      end: 142
+    - source: $iv = "1234567890abcdef";
+      style: secondary
+      start: 117
+      end: 142
+    - source: $method
+      style: secondary
+      start: 52
+      end: 59
+    - source: '"AES-256-CBC"'
+      style: secondary
+      start: 62
+      end: 75
+    - source: $method = "AES-256-CBC"
+      style: secondary
+      start: 52
+      end: 75
+    - source: $method = "AES-256-CBC";
+      style: secondary
+      start: 52
+      end: 76
+    - source: $method = "AES-256-CBC";
+      style: secondary
+      start: 52
+      end: 76
+  ? |
+    <?php
+    function encryptBad4($plaintext, $password) {
+    $key = hash('sha256', $password, true);
+    $iv = "abcdef1234567890"; // Another static IV
+    $ciphertext = openssl_encrypt($plaintext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv);
+    $hash = hash_hmac('sha256', $ciphertext . $iv, $key, true);
+    return $iv . $hash . $ciphertext;
+    }
+  : labels:
+    - source: openssl_encrypt($plaintext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv)
+      style: primary
+      start: 153
+      end: 224
+    - source: openssl_encrypt
+      style: secondary
+      start: 153
+      end: 168
+    - source: '"AES-256-CBC"'
+      style: secondary
+      start: 181
+      end: 194
+    - source: '"AES-256-CBC"'
+      style: secondary
+      start: 181
+      end: 194
+    - source: $iv
+      style: secondary
+      start: 220
+      end: 223
+    - source: $iv
+      style: secondary
+      start: 220
+      end: 223
+    - source: ($plaintext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv)
+      style: secondary
+      start: 168
+      end: 224
+    - source: $iv
+      style: secondary
+      start: 92
+      end: 95
+    - source: '"abcdef1234567890"'
+      style: secondary
+      start: 98
+      end: 116
+    - source: $iv = "abcdef1234567890"
+      style: secondary
+      start: 92
+      end: 116
+    - source: $iv = "abcdef1234567890";
+      style: secondary
+      start: 92
+      end: 117
+    - source: $iv = "abcdef1234567890";
+      style: secondary
+      start: 92
+      end: 117

--- a/tests/__snapshots__/ruby-mysql2-empty-password-ruby-snapshot.yml
+++ b/tests/__snapshots__/ruby-mysql2-empty-password-ruby-snapshot.yml
@@ -4,6 +4,72 @@ snapshots:
     $LOAD_PATH.unshift 'lib'
     require 'mysql2'
     require 'timeout'
+    Mysql2::Client.new(host: "localhost", username: "root", password: "").query("SELECT sleep(#{overhead}) as result")
+  : labels:
+    - source: 'Mysql2::Client.new(host: "localhost", username: "root", password: "")'
+      style: primary
+      start: 60
+      end: 129
+    - source: Mysql2
+      style: secondary
+      start: 60
+      end: 66
+    - source: Client
+      style: secondary
+      start: 68
+      end: 74
+    - source: Mysql2::Client
+      style: secondary
+      start: 60
+      end: 74
+    - source: new
+      style: secondary
+      start: 75
+      end: 78
+    - source: password
+      style: secondary
+      start: 116
+      end: 124
+    - source: '""'
+      style: secondary
+      start: 126
+      end: 128
+    - source: 'password: ""'
+      style: secondary
+      start: 116
+      end: 128
+    - source: '(host: "localhost", username: "root", password: "")'
+      style: secondary
+      start: 78
+      end: 129
+    - source: require
+      style: secondary
+      start: 25
+      end: 32
+    - source: mysql2
+      style: secondary
+      start: 34
+      end: 40
+    - source: '''mysql2'''
+      style: secondary
+      start: 33
+      end: 41
+    - source: '''mysql2'''
+      style: secondary
+      start: 33
+      end: 41
+    - source: require 'mysql2'
+      style: secondary
+      start: 25
+      end: 41
+    - source: require 'mysql2'
+      style: secondary
+      start: 25
+      end: 41
+  ? |
+    $LOAD_PATH.unshift 'lib'
+    require 'mysql2'
+    require 'timeout'
     pw = ""
     conn1 = Mysql2::Client.new(host: "localhost", username: "root", password: pw)
   : labels:

--- a/tests/__snapshots__/search-active-debug-php-snapshot.yml
+++ b/tests/__snapshots__/search-active-debug-php-snapshot.yml
@@ -1,0 +1,226 @@
+id: search-active-debug-php
+snapshots:
+  ? |
+    <?php
+    define("WP_DEBUG",true);
+  : labels:
+    - source: define("WP_DEBUG",true)
+      style: primary
+      start: 6
+      end: 29
+    - source: define
+      style: secondary
+      start: 6
+      end: 12
+    - source: WP_DEBUG
+      style: secondary
+      start: 14
+      end: 22
+    - source: '"WP_DEBUG"'
+      style: secondary
+      start: 13
+      end: 23
+    - source: '"WP_DEBUG"'
+      style: secondary
+      start: 13
+      end: 23
+    - source: 'true'
+      style: secondary
+      start: 24
+      end: 28
+    - source: 'true'
+      style: secondary
+      start: 24
+      end: 28
+    - source: ("WP_DEBUG",true)
+      style: secondary
+      start: 12
+      end: 29
+  ? |
+    <?php
+    ini_set("display_errors","ON");
+  : labels:
+    - source: ini_set("display_errors","ON")
+      style: primary
+      start: 6
+      end: 36
+    - source: ini_set
+      style: secondary
+      start: 6
+      end: 13
+    - source: display_errors
+      style: secondary
+      start: 15
+      end: 29
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: ON
+      style: secondary
+      start: 32
+      end: 34
+    - source: '"ON"'
+      style: secondary
+      start: 31
+      end: 35
+    - source: '"ON"'
+      style: secondary
+      start: 31
+      end: 35
+    - source: ("display_errors","ON")
+      style: secondary
+      start: 13
+      end: 36
+  ? |
+    <?php
+    ini_set("display_errors","on");
+  : labels:
+    - source: ini_set("display_errors","on")
+      style: primary
+      start: 6
+      end: 36
+    - source: ini_set
+      style: secondary
+      start: 6
+      end: 13
+    - source: display_errors
+      style: secondary
+      start: 15
+      end: 29
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: on
+      style: secondary
+      start: 32
+      end: 34
+    - source: '"on"'
+      style: secondary
+      start: 31
+      end: 35
+    - source: '"on"'
+      style: secondary
+      start: 31
+      end: 35
+    - source: ("display_errors","on")
+      style: secondary
+      start: 13
+      end: 36
+  ? |
+    <?php
+    ini_set("display_errors",1);
+  : labels:
+    - source: ini_set("display_errors",1)
+      style: primary
+      start: 6
+      end: 33
+    - source: ini_set
+      style: secondary
+      start: 6
+      end: 13
+    - source: display_errors
+      style: secondary
+      start: 15
+      end: 29
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: '1'
+      style: secondary
+      start: 31
+      end: 32
+    - source: '1'
+      style: secondary
+      start: 31
+      end: 32
+    - source: ("display_errors",1)
+      style: secondary
+      start: 13
+      end: 33
+  ? |
+    <?php
+    ini_set("display_errors",TRUE);
+  : labels:
+    - source: ini_set("display_errors",TRUE)
+      style: primary
+      start: 6
+      end: 36
+    - source: ini_set
+      style: secondary
+      start: 6
+      end: 13
+    - source: display_errors
+      style: secondary
+      start: 15
+      end: 29
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: 'TRUE'
+      style: secondary
+      start: 31
+      end: 35
+    - source: 'TRUE'
+      style: secondary
+      start: 31
+      end: 35
+    - source: ("display_errors",TRUE)
+      style: secondary
+      start: 13
+      end: 36
+  ? |
+    <?php
+    ini_set("display_errors",true);
+  : labels:
+    - source: ini_set("display_errors",true)
+      style: primary
+      start: 6
+      end: 36
+    - source: ini_set
+      style: secondary
+      start: 6
+      end: 13
+    - source: display_errors
+      style: secondary
+      start: 15
+      end: 29
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: '"display_errors"'
+      style: secondary
+      start: 14
+      end: 30
+    - source: 'true'
+      style: secondary
+      start: 31
+      end: 35
+    - source: 'true'
+      style: secondary
+      start: 31
+      end: 35
+    - source: ("display_errors",true)
+      style: secondary
+      start: 13
+      end: 36

--- a/tests/php/openssl-cbc-static-iv-php-test.yml
+++ b/tests/php/openssl-cbc-static-iv-php-test.yml
@@ -1,0 +1,63 @@
+id: openssl-cbc-static-iv-php
+valid:
+  - |
+    <?php
+    function encrypt($plaintext, $password) {
+    $method = "AES-256-CBC";
+    $key = hash('sha256', $password, true);
+    $iv = openssl_random_pseudo_bytes(16);
+    $ciphertext = openssl_encrypt($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv);
+    $hash = hash_hmac('sha256', $ciphertext . $iv, $key, true);
+    return $iv . $hash . $ciphertext;
+    }
+invalid:
+  - |
+    <?php
+    function encryptBad($plaintext, $password) {
+    $method = "AES-256-CBC";
+    $key = hash('sha256', $password, true);
+    $iv = "4c25ecc95c8816db753cba44a3b56aca";
+    $ciphertext = openssl_encrypt($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv);
+    $hash = hash_hmac('sha256', $ciphertext . $iv, $key, true);
+    return $iv . $hash . $ciphertext;
+    }
+  - |
+     <?php
+     function decryptBad4($ivHashCiphertext, $password) {
+     $iv = "abcdef1234567890"; // Static IV
+     $hash = substr($ivHashCiphertext, 16, 32);
+     $ciphertext = substr($ivHashCiphertext, 48);
+     $key = hash('sha256', $password, true);
+     if (!hash_equals(hash_hmac('sha256', $ciphertext . $iv, $key, true), $hash)) return null;
+     return openssl_decrypt($ciphertext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv);
+     }
+  - |
+     <?php
+     function encryptBad4($plaintext, $password) {
+     $key = hash('sha256', $password, true);
+     $iv = "abcdef1234567890"; // Another static IV
+     $ciphertext = openssl_encrypt($plaintext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv);
+     $hash = hash_hmac('sha256', $ciphertext . $iv, $key, true);
+     return $iv . $hash . $ciphertext;
+     }
+  - |
+     <?php
+     function decryptBad3($ivHashCiphertext, $password) {
+     $method = "AES-256-CBC";
+     $iv = "1234567890abcdef"; // Static IV
+     $hash = substr($ivHashCiphertext, 16, 32);
+     $ciphertext = substr($ivHashCiphertext, 48);
+     $key = hash('sha256', $password, true);
+     if (!hash_equals(hash_hmac('sha256', $ciphertext . $iv, $key, true), $hash)) return null;
+     return openssl_decrypt($ciphertext, $method, $key, OPENSSL_RAW_DATA, $iv);
+     }
+  - |
+     <?php
+     function encryptBad3($plaintext, $password) {
+     $method = "AES-256-CBC";
+     $key = hash('sha256', $password, true);
+     $iv = "1234567890abcdef"; // Static IV
+     $ciphertext = openssl_encrypt($plaintext, $method, $key, OPENSSL_RAW_DATA, $iv);
+     $hash = hash_hmac('sha256', $ciphertext . $iv, $key, true);
+     return $iv . $hash . $ciphertext;
+     }

--- a/tests/php/search-active-debug-php-test.yml
+++ b/tests/php/search-active-debug-php-test.yml
@@ -1,0 +1,27 @@
+id: search-active-debug-php
+valid:
+  - |
+    <?php
+    ini_set("display_errors",0);
+  - |
+    <?php
+    ini_set("display_errors","off");
+invalid:
+  - |
+    <?php
+    ini_set("display_errors",1);
+  - |
+    <?php
+    define("WP_DEBUG",true);
+  - |
+    <?php
+    ini_set("display_errors",true);
+  - |
+    <?php
+    ini_set("display_errors","on");
+  - |
+    <?php
+    ini_set("display_errors",TRUE);
+  - |
+    <?php
+    ini_set("display_errors","ON");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced security checks for PHP applications to detect insecure encryption practices and improper debug logging settings.

- **Tests**
  - Expanded test coverage with new scenarios and snapshots validating encryption integrity, error display configurations, and secure database connection setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->