### PR TITLE
Add YAML rules to detect hard-coded connection passwords in Java

### DIFF
--- a/rules/java/security/datanucleus-hardcoded-connection-password-java.yml
+++ b/rules/java/security/datanucleus-hardcoded-connection-password-java.yml
@@ -1,0 +1,593 @@
+id: datanucleus-hardcoded-connection-password-java
+severity: warning
+language: java
+message: >-
+      A secret is hard-coded in the application. Secrets stored in source
+      code, such as credentials, identifiers, and other types of sensitive data,
+      can be leaked and used by internal or external malicious actors. Use
+      environment variables to securely provide credentials and other secrets or
+      retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798] Use of Hard-coded Credentials.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+      - https://db.apache.org/jdo/api30/apidocs/javax/jdo/PersistenceManagerFactory.html
+
+ast-grep-essentials: true
+
+utils:
+  
+  (org.datanucleus.api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("..."):
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          has:
+            kind: string_literal
+            has:
+              kind: string_fragment
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^org.datanucleus.api.jdo.JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+
+  (org.datanucleus.api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance:
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: identifier
+            pattern: $PSWD
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^org.datanucleus.api.jdo.JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            has:
+              kind: variable_declarator
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $PSWD
+                - has:
+                    kind: string_literal
+                    has:
+                      kind: string_fragment
+
+  (jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("..."):
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: string_literal
+            has:
+              kind: string_fragment
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^jdo.JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import org.datanucleus.api.*;
+              - pattern: import org.datanucleus.api;
+
+  (jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance:
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: identifier
+            pattern: $PSWD
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^jdo.JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            has:
+              kind: variable_declarator
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $PSWD
+                - has:
+                    kind: string_literal
+                    has:
+                      kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import org.datanucleus.api.*;
+              - pattern: import org.datanucleus.api;
+
+  (JDOPersistenceManagerFactory $JDO). ... .$SETPASS("..."):
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: string_literal
+            has:
+              kind: string_fragment
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: type_identifier
+                  regex: ^JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import org.datanucleus.*;
+              - pattern: import org.datanucleus;
+              - pattern: import org.datanucleus.api.jdo.*;
+              - pattern: import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+
+  (JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance:
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: identifier
+            pattern: $PSWD
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: type_identifier
+                  regex: ^JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: field_declaration
+            - kind: local_variable_declaration
+            has:
+              kind: variable_declarator
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $PSWD
+                - has:
+                    kind: string_literal
+                    has:
+                      kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import org.datanucleus.api.jdo.*;
+              - pattern: import org.datanucleus.*;
+              - pattern: import org.datanucleus;
+              - pattern: import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+
+  (api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("..."):
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: string_literal
+            has:
+              kind: string_fragment
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^api.jdo.JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import org.datanucleus.*;
+              - pattern: import org.datanucleus;
+
+  (api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance:
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: identifier
+            pattern: $PSWD
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^api.jdo.JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            has:
+              kind: variable_declarator
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $PSWD
+                - has:
+                    kind: string_literal
+                    has:
+                      kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import org.datanucleus.*;
+              - pattern: import org.datanucleus;
+
+  (datanucleus.api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("..."):
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: string_literal
+            has:
+              kind: string_fragment
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^datanucleus.api.jdo.JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import org.*;
+              - pattern: import org;
+
+  (datanucleus.api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance:
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: identifier
+            pattern: $PSWD
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^datanucleus.api.jdo.JDOPersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            has:
+              kind: variable_declarator
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $PSWD
+                - has:
+                    kind: string_literal
+                    has:
+                      kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import org.*;
+              - pattern: import org;
+
+
+rule:
+  any:
+    - matches: (org.datanucleus.api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")
+    - matches: (org.datanucleus.api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance
+    - matches: (jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")
+    - matches: (jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance
+    - matches: (JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")
+    - matches: (JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance
+    - matches: (api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")
+    - matches: (api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance
+    - matches: (datanucleus.api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")
+    - matches: (datanucleus.api.jdo.JDOPersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance
+    

--- a/rules/java/security/hardcoded-connection-password-java.yml
+++ b/rules/java/security/hardcoded-connection-password-java.yml
@@ -1,0 +1,352 @@
+id: hardcoded-connection-password-java
+severity: warning
+language: java
+message: >-
+      A secret is hard-coded in the application. Secrets stored in source
+      code, such as credentials, identifiers, and other types of sensitive data,
+      can be leaked and used by internal or external malicious actors. Use
+      environment variables to securely provide credentials and other secrets or
+      retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798] Use of Hard-coded Credentials.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+      - https://db.apache.org/jdo/api30/apidocs/javax/jdo/PersistenceManagerFactory.html
+
+ast-grep-essentials: true
+
+utils:
+  
+  (javax.jdo.PersistenceManagerFactory $JDO). ... .$SETPASS("..."):
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          has:
+            kind: string_literal
+            has:
+              kind: string_fragment
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^javax.jdo.PersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+
+  (javax.jdo.PersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance:
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: identifier
+            pattern: $PSWD
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^javax.jdo.PersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            has:
+              kind: variable_declarator
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $PSWD
+                - has:
+                    kind: string_literal
+                    has:
+                      kind: string_fragment
+
+  (jdo.PersistenceManagerFactory $JDO). ... .$SETPASS("..."):
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: string_literal
+            has:
+              kind: string_fragment
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^jdo.PersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import javax.*;
+
+  (jdo.PersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance:
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: identifier
+            pattern: $PSWD
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^jdo.PersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            has:
+              kind: variable_declarator
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $PSWD
+                - has:
+                    kind: string_literal
+                    has:
+                      kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import javax.*;
+
+  (PersistenceManagerFactory $JDO). ... .$SETPASS("..."):
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: string_literal
+            has:
+              kind: string_fragment
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: type_identifier
+                  regex: ^PersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import javax.jdo.*;
+              - pattern: import javax.jdo.PersistenceManagerFactory;
+
+  (PersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance:
+    kind: identifier
+    regex: ^setConnectionPassword$
+    all:
+      - precedes:
+          kind: argument_list
+          not:
+            has:
+              nthChild: 
+                position: 2
+                ofRule:
+                  not:
+                    kind: line_comment
+          has:
+            kind: identifier
+            pattern: $PSWD
+      - inside:
+         stopBy: end
+         kind: method_invocation
+         has:
+           stopBy: end
+           kind: identifier
+           pattern: $INST
+           nthChild: 1
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: local_variable_declaration
+            - kind: field_declaration
+            all:
+              - has:
+                  kind: type_identifier
+                  regex: ^PersistenceManagerFactory$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+            - kind: field_declaration
+            - kind: local_variable_declaration
+            has:
+              kind: variable_declarator
+              all:
+                - has:
+                    kind: identifier
+                    pattern: $PSWD
+                - has:
+                    kind: string_literal
+                    has:
+                      kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            any:
+              - pattern: import javax.jdo.*;
+              - pattern: import javax.jdo.PersistenceManagerFactory;
+rule:
+  any:
+    - matches: (javax.jdo.PersistenceManagerFactory $JDO). ... .$SETPASS("...")
+    - matches: (javax.jdo.PersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance
+    - matches: (jdo.PersistenceManagerFactory $JDO). ... .$SETPASS("...")
+    - matches: (jdo.PersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance
+    - matches: (PersistenceManagerFactory $JDO). ... .$SETPASS("...")
+    - matches: (PersistenceManagerFactory $JDO). ... .$SETPASS("...")_with_Instance

--- a/rules/java/security/jedis-jedisclientconfig-hardcoded-password-java.yml
+++ b/rules/java/security/jedis-jedisclientconfig-hardcoded-password-java.yml
@@ -1,0 +1,830 @@
+id: jedis-jedisclientconfig-hardcoded-password-java
+language: java
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source
+  code, such as credentials, identifiers, and other types of sensitive data,
+  can be leaked and used by internal or external malicious actors. Use
+  environment variables to securely provide credentials and other secrets or
+  retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798] Use of Hard-coded Credentials.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+ast-grep-essentials: true
+
+utils:
+  redis.clients.jedis.DefaultJedisClientConfig.builder().password("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: method_invocation
+          pattern: redis.clients.jedis.DefaultJedisClientConfig.builder()
+      - has:
+          kind: identifier
+          regex: 'password'
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has: 
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+
+  (redis.clients.jedis.DefaultJedisClientConfig.Builder $JEDIS).password("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^password$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^redis.clients.jedis.DefaultJedisClientConfig.Builder$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+
+  redis.clients.jedis.DefaultJedisClientConfig.create($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "..."):
+    kind: method_invocation
+    all:
+      - has:
+          kind: field_access
+          nthChild: 1
+          regex: ^redis.clients.jedis.DefaultJedisClientConfig$
+      - has:
+          kind: identifier
+          regex: ^create$
+      - has:
+          kind: argument_list
+          has:
+            kind: string_literal
+            nthChild: 
+              position: 5
+              ofRule:
+                not:
+                  kind: line_comment
+            has:
+              kind: string_fragment
+          
+  new redis.clients.jedis.DefaultJedisClientConfig($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "..."):
+    kind: object_creation_expression
+    all:
+      - has:
+          kind: scoped_type_identifier
+          regex: ^redis.clients.jedis.DefaultJedisClientConfig$
+          nthChild: 1
+      - has:
+          kind: argument_list
+          nthChild: 2
+          has:
+            kind: string_literal
+            nthChild: 5
+            has:
+              kind: string_fragment
+
+  (redis.clients.jedis.JedisClientConfig $JEDIS).updatePassword("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^updatePassword$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^redis.clients.jedis.JedisClientConfig$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+
+  (redis.clients.jedis.DefaultJedisClientConfig $JEDIS).updatePassword("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^updatePassword$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^redis.clients.jedis.DefaultJedisClientConfig$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+
+  DefaultJedisClientConfig.builder().password("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: method_invocation
+          pattern: DefaultJedisClientConfig.builder()
+      - has:
+          kind: identifier
+          regex: 'password'
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has: 
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.jedis.*;
+              - pattern: import redis.clients.jedis;
+              - pattern: import redis.clients.jedis.DefaultJedisClientConfig;
+
+  (DefaultJedisClientConfig.Builder $JEDIS).password("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^password$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^DefaultJedisClientConfig.Builder$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.jedis.*;
+              - pattern: import redis.clients.jedis;
+              - pattern: import redis.clients.jedis.DefaultJedisClientConfig;
+
+  DefaultJedisClientConfig.create($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "..."):
+    kind: method_invocation
+    all:
+      - has:
+          kind: identifier
+          nthChild: 1
+          regex: ^DefaultJedisClientConfig$
+      - has:
+          kind: identifier
+          regex: ^create$
+      - has:
+          kind: argument_list
+          has:
+            kind: string_literal
+            nthChild: 
+              position: 5
+              ofRule:
+                not:
+                  kind: line_comment
+            has:
+              kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.jedis.*;
+              - pattern: import redis.clients.jedis;
+              - pattern: import redis.clients.jedis.DefaultJedisClientConfig;
+    
+  new DefaultJedisClientConfig($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "..."):
+    kind: object_creation_expression
+    all:
+      - has:
+          kind: type_identifier
+          regex: ^DefaultJedisClientConfig$
+          nthChild: 1
+      - has:
+          kind: argument_list
+          nthChild: 2
+          has:
+            kind: string_literal
+            nthChild: 5
+            has:
+              kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.jedis.*;
+              - pattern: import redis.clients.jedis;
+              - pattern: import redis.clients.jedis.DefaultJedisClientConfig;
+    
+  (JedisClientConfig|DefaultJedisClientConfig $JEDIS).updatePassword("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^updatePassword$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: type_identifier
+                  regex: ^(JedisClientConfig|DefaultJedisClientConfig)$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.jedis.*;
+              - pattern: import redis.clients.jedis;
+              - pattern: import redis.clients.jedis.DefaultJedisClientConfig;
+
+  jedis.DefaultJedisClientConfig.builder().password("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: method_invocation
+          pattern: jedis.DefaultJedisClientConfig.builder()
+      - has:
+          kind: identifier
+          regex: 'password'
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has: 
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.*;
+              - pattern: import redis.clients;
+ 
+  jedis.DefaultJedisClientConfig.Builder $JEDIS).password("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^password$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^jedis.DefaultJedisClientConfig.Builder$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.*;
+              - pattern: import redis.clients;
+
+  jedis.DefaultJedisClientConfig.create($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "..."):
+    kind: method_invocation
+    all:
+      - has:
+          kind: field_access
+          nthChild: 1
+          regex: ^jedis.DefaultJedisClientConfig$
+      - has:
+          kind: identifier
+          regex: ^create$
+      - has:
+          kind: argument_list
+          has:
+            kind: string_literal
+            nthChild: 
+              position: 5
+              ofRule:
+                not:
+                  kind: line_comment
+            has:
+              kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.*;
+              - pattern: import redis.clients;
+
+  new jedis.DefaultJedisClientConfig($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "..."):
+    kind: object_creation_expression
+    all:
+      - has:
+          kind: scoped_type_identifier
+          regex: ^jedis.DefaultJedisClientConfig$
+          nthChild: 1
+      - has:
+          kind: argument_list
+          nthChild: 2
+          has:
+            kind: string_literal
+            nthChild: 5
+            has:
+              kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.*;
+              - pattern: import redis.clients;
+
+  (jedis.JedisClientConfig|jedis.DefaultJedisClientConfig $JEDIS).updatePassword("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^updatePassword$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^(jedis.JedisClientConfig|jedis.DefaultJedisClientConfig)$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.clients.*;
+              - pattern: import redis.clients;
+              - pattern: import redis.clients.jedis.*;
+
+  clients.jedis.DefaultJedisClientConfig.builder().password("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: method_invocation
+          pattern: clients.jedis.DefaultJedisClientConfig.builder()
+      - has:
+          kind: identifier
+          regex: 'password'
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has: 
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.*;
+              - pattern: import redis;
+
+  clients.jedis.DefaultJedisClientConfig.Builder $JEDIS).password("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^password$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^clients.jedis.DefaultJedisClientConfig.Builder$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.*;
+              - pattern: import redis;
+
+  clients.jedis.DefaultJedisClientConfig.create($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "..."):
+    kind: method_invocation
+    all:
+      - has:
+          kind: field_access
+          nthChild: 1
+          regex: ^clients.jedis.DefaultJedisClientConfig$
+      - has:
+          kind: identifier
+          regex: ^create$
+      - has:
+          kind: argument_list
+          has:
+            kind: string_literal
+            nthChild: 
+              position: 5
+              ofRule:
+                not:
+                  kind: line_comment
+            has:
+              kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.*;
+              - pattern: import redis;
+
+  new clients.jedis.DefaultJedisClientConfig($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "..."):
+    kind: object_creation_expression
+    all:
+      - has:
+          kind: scoped_type_identifier
+          regex: ^clients.jedis.DefaultJedisClientConfig$
+          nthChild: 1
+      - has:
+          kind: argument_list
+          nthChild: 2
+          has:
+            kind: string_literal
+            nthChild: 5
+            has:
+              kind: string_fragment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.*;
+              - pattern: import redis;
+
+  (clients.jedis.JedisClientConfig|clients.jedis.DefaultJedisClientConfig $JEDIS).updatePassword("..."):
+    kind: method_invocation
+    all:
+      - has:
+          stopBy: end
+          kind: identifier
+          pattern: $INST
+          nthChild: 1
+      - has:
+          kind: identifier
+          regex: ^updatePassword$
+          precedes:
+            kind: argument_list
+            has:
+              kind: string_literal
+              nthChild: 
+                position: 1
+                ofRule:
+                  not:
+                    kind: line_comment
+              has:
+                kind: string_fragment
+            not:
+              has:
+                nthChild: 
+                  position: 2
+                  ofRule:
+                    not:
+                      kind: line_comment
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: local_variable_declaration
+            all:
+              - has:
+                  kind: scoped_type_identifier
+                  regex: ^(clients.jedis.JedisClientConfig|clients.jedis.DefaultJedisClientConfig)$
+              - has:
+                  kind: variable_declarator
+                  has:
+                    kind: identifier
+                    pattern: $INST
+      - inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: import_declaration
+            any:
+              - pattern: import redis.*;
+              - pattern: import redis;
+
+rule:
+  any:
+    - matches: redis.clients.jedis.DefaultJedisClientConfig.builder().password("...")
+    - matches: (redis.clients.jedis.DefaultJedisClientConfig.Builder $JEDIS).password("...")
+    - matches: redis.clients.jedis.DefaultJedisClientConfig.create($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "...")
+    - matches: new redis.clients.jedis.DefaultJedisClientConfig($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "...")
+    - matches: (redis.clients.jedis.JedisClientConfig $JEDIS).updatePassword("...")
+    - matches: (redis.clients.jedis.DefaultJedisClientConfig $JEDIS).updatePassword("...")
+    - matches: DefaultJedisClientConfig.builder().password("...")
+    - matches: (DefaultJedisClientConfig.Builder $JEDIS).password("...")
+    - matches: DefaultJedisClientConfig.create($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "...")
+    - matches: new DefaultJedisClientConfig($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "...")
+    - matches: (JedisClientConfig|DefaultJedisClientConfig $JEDIS).updatePassword("...")
+    - matches: jedis.DefaultJedisClientConfig.builder().password("...")
+    - matches: jedis.DefaultJedisClientConfig.Builder $JEDIS).password("...")
+    - matches: jedis.DefaultJedisClientConfig.create($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "...")
+    - matches: new jedis.DefaultJedisClientConfig($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "...")
+    - matches: (jedis.JedisClientConfig|jedis.DefaultJedisClientConfig $JEDIS).updatePassword("...")
+    - matches: clients.jedis.DefaultJedisClientConfig.builder().password("...")
+    - matches: clients.jedis.DefaultJedisClientConfig.Builder $JEDIS).password("...")
+    - matches: clients.jedis.DefaultJedisClientConfig.create($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "...")
+    - matches: new clients.jedis.DefaultJedisClientConfig($CONNECTIONTIMEOUTMILLIS, $SOTIMEOUTMILLIS, $BLOCKINGSOCKETTIMEOUTMILLIS, $USER, "...")
+    - matches: (clients.jedis.JedisClientConfig|clients.jedis.DefaultJedisClientConfig $JEDIS).updatePassword("...")

--- a/tests/__snapshots__/datanucleus-hardcoded-connection-password-java-snapshot.yml
+++ b/tests/__snapshots__/datanucleus-hardcoded-connection-password-java-snapshot.yml
@@ -1,0 +1,145 @@
+id: datanucleus-hardcoded-connection-password-java
+snapshots:
+  ? |-
+    import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+    public class PeopleTest {
+    JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+    private String pw = "asdf";
+    public void setUp() throws SQLException {
+    pmf.setConnectionPassword(pw);
+    }
+    }
+  : labels:
+    - source: setConnectionPassword
+      style: primary
+      start: 237
+      end: 258
+    - source: pw
+      style: secondary
+      start: 259
+      end: 261
+    - source: (pw)
+      style: secondary
+      start: 258
+      end: 262
+    - source: pmf
+      style: secondary
+      start: 233
+      end: 236
+    - source: pmf.setConnectionPassword(pw)
+      style: secondary
+      start: 233
+      end: 262
+    - source: JDOPersistenceManagerFactory
+      style: secondary
+      start: 87
+      end: 115
+    - source: pmf
+      style: secondary
+      start: 116
+      end: 119
+    - source: pmf = new JDOPersistenceManagerFactory(props)
+      style: secondary
+      start: 116
+      end: 161
+    - source: JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+      style: secondary
+      start: 87
+      end: 162
+    - source: JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+      style: secondary
+      start: 87
+      end: 162
+    - source: pw
+      style: secondary
+      start: 178
+      end: 180
+    - source: asdf
+      style: secondary
+      start: 184
+      end: 188
+    - source: '"asdf"'
+      style: secondary
+      start: 183
+      end: 189
+    - source: pw = "asdf"
+      style: secondary
+      start: 178
+      end: 189
+    - source: private String pw = "asdf";
+      style: secondary
+      start: 163
+      end: 190
+    - source: private String pw = "asdf";
+      style: secondary
+      start: 163
+      end: 190
+    - source: import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+      style: secondary
+      start: 0
+      end: 60
+    - source: import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+      style: secondary
+      start: 0
+      end: 60
+  ? |
+    import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+    public class PeopleTest {
+    JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+    public void setUp() throws SQLException {
+    pmf.setConnectionPassword("asdf");
+    }
+    }
+  : labels:
+    - source: setConnectionPassword
+      style: primary
+      start: 209
+      end: 230
+    - source: asdf
+      style: secondary
+      start: 232
+      end: 236
+    - source: '"asdf"'
+      style: secondary
+      start: 231
+      end: 237
+    - source: ("asdf")
+      style: secondary
+      start: 230
+      end: 238
+    - source: pmf
+      style: secondary
+      start: 205
+      end: 208
+    - source: pmf.setConnectionPassword("asdf")
+      style: secondary
+      start: 205
+      end: 238
+    - source: JDOPersistenceManagerFactory
+      style: secondary
+      start: 87
+      end: 115
+    - source: pmf
+      style: secondary
+      start: 116
+      end: 119
+    - source: pmf = new JDOPersistenceManagerFactory(props)
+      style: secondary
+      start: 116
+      end: 161
+    - source: JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+      style: secondary
+      start: 87
+      end: 162
+    - source: JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+      style: secondary
+      start: 87
+      end: 162
+    - source: import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+      style: secondary
+      start: 0
+      end: 60
+    - source: import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+      style: secondary
+      start: 0
+      end: 60

--- a/tests/__snapshots__/hardcoded-connection-password-java-snapshot.yml
+++ b/tests/__snapshots__/hardcoded-connection-password-java-snapshot.yml
@@ -1,0 +1,147 @@
+id: hardcoded-connection-password-java
+snapshots:
+  ? |-
+    import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+    import javax.jdo.PersistenceManagerFactory;
+    public class PeopleTest {
+    private PersistenceManagerFactory pmf;
+    private String pw = "asdf";
+    public void setUp() throws SQLException {
+    pmf.setConnectionPassword(pw);
+    }
+    }
+  : labels:
+    - source: setConnectionPassword
+      style: primary
+      start: 244
+      end: 265
+    - source: pw
+      style: secondary
+      start: 266
+      end: 268
+    - source: (pw)
+      style: secondary
+      start: 265
+      end: 269
+    - source: pmf
+      style: secondary
+      start: 240
+      end: 243
+    - source: pmf.setConnectionPassword(pw)
+      style: secondary
+      start: 240
+      end: 269
+    - source: PersistenceManagerFactory
+      style: secondary
+      start: 139
+      end: 164
+    - source: pmf
+      style: secondary
+      start: 165
+      end: 168
+    - source: pmf
+      style: secondary
+      start: 165
+      end: 168
+    - source: private PersistenceManagerFactory pmf;
+      style: secondary
+      start: 131
+      end: 169
+    - source: private PersistenceManagerFactory pmf;
+      style: secondary
+      start: 131
+      end: 169
+    - source: pw
+      style: secondary
+      start: 185
+      end: 187
+    - source: asdf
+      style: secondary
+      start: 191
+      end: 195
+    - source: '"asdf"'
+      style: secondary
+      start: 190
+      end: 196
+    - source: pw = "asdf"
+      style: secondary
+      start: 185
+      end: 196
+    - source: private String pw = "asdf";
+      style: secondary
+      start: 170
+      end: 197
+    - source: private String pw = "asdf";
+      style: secondary
+      start: 170
+      end: 197
+    - source: import javax.jdo.PersistenceManagerFactory;
+      style: secondary
+      start: 61
+      end: 104
+    - source: import javax.jdo.PersistenceManagerFactory;
+      style: secondary
+      start: 61
+      end: 104
+  ? |
+    import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+    import javax.jdo.PersistenceManagerFactory;
+    public class PeopleTest {
+    private PersistenceManagerFactory pmf;
+    public void setUp() throws SQLException {
+    pmf.setConnectionPassword("asdf");
+    }
+    }
+  : labels:
+    - source: setConnectionPassword
+      style: primary
+      start: 216
+      end: 237
+    - source: asdf
+      style: secondary
+      start: 239
+      end: 243
+    - source: '"asdf"'
+      style: secondary
+      start: 238
+      end: 244
+    - source: ("asdf")
+      style: secondary
+      start: 237
+      end: 245
+    - source: pmf
+      style: secondary
+      start: 212
+      end: 215
+    - source: pmf.setConnectionPassword("asdf")
+      style: secondary
+      start: 212
+      end: 245
+    - source: PersistenceManagerFactory
+      style: secondary
+      start: 139
+      end: 164
+    - source: pmf
+      style: secondary
+      start: 165
+      end: 168
+    - source: pmf
+      style: secondary
+      start: 165
+      end: 168
+    - source: private PersistenceManagerFactory pmf;
+      style: secondary
+      start: 131
+      end: 169
+    - source: private PersistenceManagerFactory pmf;
+      style: secondary
+      start: 131
+      end: 169
+    - source: import javax.jdo.PersistenceManagerFactory;
+      style: secondary
+      start: 61
+      end: 104
+    - source: import javax.jdo.PersistenceManagerFactory;
+      style: secondary
+      start: 61
+      end: 104

--- a/tests/__snapshots__/jedis-jedisclientconfig-hardcoded-password-java-snapshot.yml
+++ b/tests/__snapshots__/jedis-jedisclientconfig-hardcoded-password-java-snapshot.yml
@@ -1,0 +1,202 @@
+id: jedis-jedisclientconfig-hardcoded-password-java
+snapshots:
+  ? |-
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder();
+        builder.password("asdf");
+    }
+    }
+  : labels:
+    - source: builder.password("asdf")
+      style: primary
+      start: 220
+      end: 244
+    - source: builder
+      style: secondary
+      start: 220
+      end: 227
+    - source: asdf
+      style: secondary
+      start: 238
+      end: 242
+    - source: '"asdf"'
+      style: secondary
+      start: 237
+      end: 243
+    - source: ("asdf")
+      style: secondary
+      start: 236
+      end: 244
+    - source: password
+      style: secondary
+      start: 228
+      end: 236
+    - source: DefaultJedisClientConfig.Builder
+      style: secondary
+      start: 137
+      end: 169
+    - source: builder
+      style: secondary
+      start: 170
+      end: 177
+    - source: builder = DefaultJedisClientConfig.builder()
+      style: secondary
+      start: 170
+      end: 214
+    - source: DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder();
+      style: secondary
+      start: 137
+      end: 215
+    - source: DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder();
+      style: secondary
+      start: 137
+      end: 215
+    - source: import redis.clients.jedis.DefaultJedisClientConfig;
+      style: secondary
+      start: 46
+      end: 98
+    - source: import redis.clients.jedis.DefaultJedisClientConfig;
+      style: secondary
+      start: 46
+      end: 98
+  ? |
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    JedisClientConfig cc = DefaultJedisClientConfig.builder()
+            .password("asdf")
+            .ssl(useSsl)
+            .build();
+    cc.updatePassword("hello");
+    }
+    }
+  : labels:
+    - source: |-
+        DefaultJedisClientConfig.builder()
+                .password("asdf")
+      style: primary
+      start: 160
+      end: 220
+    - source: DefaultJedisClientConfig.builder()
+      style: secondary
+      start: 160
+      end: 194
+    - source: asdf
+      style: secondary
+      start: 214
+      end: 218
+    - source: '"asdf"'
+      style: secondary
+      start: 213
+      end: 219
+    - source: ("asdf")
+      style: secondary
+      start: 212
+      end: 220
+    - source: password
+      style: secondary
+      start: 204
+      end: 212
+    - source: import redis.clients.jedis.DefaultJedisClientConfig;
+      style: secondary
+      start: 46
+      end: 98
+    - source: import redis.clients.jedis.DefaultJedisClientConfig;
+      style: secondary
+      start: 46
+      end: 98
+  ? |
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    JedisClientConfig cc = DefaultJedisClientConfig.builder()
+            .password("asdf")
+            .ssl(useSsl)
+            .build();
+    }
+    }
+  : labels:
+    - source: |-
+        DefaultJedisClientConfig.builder()
+                .password("asdf")
+      style: primary
+      start: 160
+      end: 220
+    - source: DefaultJedisClientConfig.builder()
+      style: secondary
+      start: 160
+      end: 194
+    - source: asdf
+      style: secondary
+      start: 214
+      end: 218
+    - source: '"asdf"'
+      style: secondary
+      start: 213
+      end: 219
+    - source: ("asdf")
+      style: secondary
+      start: 212
+      end: 220
+    - source: password
+      style: secondary
+      start: 204
+      end: 212
+    - source: import redis.clients.jedis.DefaultJedisClientConfig;
+      style: secondary
+      start: 46
+      end: 98
+    - source: import redis.clients.jedis.DefaultJedisClientConfig;
+      style: secondary
+      start: 46
+      end: 98
+  ? |
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    new DefaultJedisClientConfig(connectionTimeoutMillis, socketTimeoutMillis,
+    blockingSocketTimeoutMillis, user, "identifier", database, clientName, ssl, sslSocketFactory,
+    sslParameters, hostnameVerifier, hostAndPortMapper);
+    }
+    }
+  : labels:
+    - source: |-
+        new DefaultJedisClientConfig(connectionTimeoutMillis, socketTimeoutMillis,
+        blockingSocketTimeoutMillis, user, "identifier", database, clientName, ssl, sslSocketFactory,
+        sslParameters, hostnameVerifier, hostAndPortMapper)
+      style: primary
+      start: 137
+      end: 357
+    - source: DefaultJedisClientConfig
+      style: secondary
+      start: 141
+      end: 165
+    - source: identifier
+      style: secondary
+      start: 248
+      end: 258
+    - source: '"identifier"'
+      style: secondary
+      start: 247
+      end: 259
+    - source: |-
+        (connectionTimeoutMillis, socketTimeoutMillis,
+        blockingSocketTimeoutMillis, user, "identifier", database, clientName, ssl, sslSocketFactory,
+        sslParameters, hostnameVerifier, hostAndPortMapper)
+      style: secondary
+      start: 165
+      end: 357
+    - source: import redis.clients.jedis.DefaultJedisClientConfig;
+      style: secondary
+      start: 46
+      end: 98
+    - source: import redis.clients.jedis.DefaultJedisClientConfig;
+      style: secondary
+      start: 46
+      end: 98

--- a/tests/java/datanucleus-hardcoded-connection-password-java-test.yml
+++ b/tests/java/datanucleus-hardcoded-connection-password-java-test.yml
@@ -1,0 +1,28 @@
+id: datanucleus-hardcoded-connection-password-java
+valid:
+  - |
+     import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+     public class PeopleTest {
+     JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+     public void setUp() throws SQLException {
+     pmf.setConnectionPassword(pw);
+     }
+     }
+invalid:
+  - |
+     import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+     public class PeopleTest {
+     JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+     public void setUp() throws SQLException {
+     pmf.setConnectionPassword("asdf");
+     }
+     }
+  - |
+     import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+     public class PeopleTest {
+     JDOPersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(props);
+     private String pw = "asdf";
+     public void setUp() throws SQLException {
+     pmf.setConnectionPassword(pw);
+     }
+     }

--- a/tests/java/hardcoded-connection-password-java-test.yml
+++ b/tests/java/hardcoded-connection-password-java-test.yml
@@ -1,0 +1,31 @@
+id: hardcoded-connection-password-java
+valid:
+  - |
+    import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+     import javax.jdo.PersistenceManagerFactory;
+     public class PeopleTest {
+     private PersistenceManagerFactory pmf;
+     public void setUp() throws SQLException {
+     pmf.setConnectionPassword(pw);
+     }
+     }
+invalid:
+  - |
+     import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+     import javax.jdo.PersistenceManagerFactory;
+     public class PeopleTest {
+     private PersistenceManagerFactory pmf;
+     public void setUp() throws SQLException {
+     pmf.setConnectionPassword("asdf");
+     }
+     }
+  - |
+     import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+     import javax.jdo.PersistenceManagerFactory;
+     public class PeopleTest {
+     private PersistenceManagerFactory pmf;
+     private String pw = "asdf";
+     public void setUp() throws SQLException {
+     pmf.setConnectionPassword(pw);
+     }
+     }

--- a/tests/java/jedis-jedisclientconfig-hardcoded-password-java-test.yml
+++ b/tests/java/jedis-jedisclientconfig-hardcoded-password-java-test.yml
@@ -1,0 +1,55 @@
+id: jedis-jedisclientconfig-hardcoded-password-java
+valid:
+  - |
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    new DefaultJedisClientConfig(connectionTimeoutMillis, socketTimeoutMillis,
+    blockingSocketTimeoutMillis, user, identifier, database, clientName, ssl, sslSocketFactory,
+    sslParameters, hostnameVerifier, hostAndPortMapper);
+    }
+    }
+invalid:
+  - |
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    new DefaultJedisClientConfig(connectionTimeoutMillis, socketTimeoutMillis,
+    blockingSocketTimeoutMillis, user, "identifier", database, clientName, ssl, sslSocketFactory,
+    sslParameters, hostnameVerifier, hostAndPortMapper);
+    }
+    }
+  - |
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    JedisClientConfig cc = DefaultJedisClientConfig.builder()
+            .password("asdf")
+            .ssl(useSsl)
+            .build();
+    }
+    }
+  - |
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    JedisClientConfig cc = DefaultJedisClientConfig.builder()
+            .password("asdf")
+            .ssl(useSsl)
+            .build();
+    cc.updatePassword("hello");
+    }
+    }
+  - |
+    import redis.clients.jedis.JedisClientConfig;
+    import redis.clients.jedis.DefaultJedisClientConfig;
+    public class JedisTest {
+    void run() {
+    DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder();
+        builder.password("asdf");
+    }
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced security rules that detect hard-coded connection passwords in Java applications, encouraging the use of secure credential management practices such as environment variables or secure vaults.

- **Tests**
  - Added comprehensive test cases to validate proper handling of connection passwords, illustrating both compliant (variable-based) and non-compliant (hard-coded) scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->