### PR TITLE
Add YAML security rules and tests for ldap3 and MariaDB

### DIFF
--- a/rules/python/security/python-ldap3-empty-password-python.yml
+++ b/rules/python/security/python-ldap3-empty-password-python.yml
@@ -1,0 +1,99 @@
+id: python-ldap3-empty-password-python
+severity: warning
+language: python
+message: >-
+      The application creates a database connection with an empty password.
+      This can lead to unauthorized access by either an internal or external
+      malicious actor. To prevent this vulnerability, enforce authentication
+      when connecting to a database by using environment variables to securely
+      provide credentials or retrieving them from a secure vault or HSM
+      (Hardware Security Module).
+note: >-
+  [CWE-287] Improper Authentication.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+ast-grep-essentials: true
+
+utils:
+  ldap3.Connection(..., password="",...)_INSTANCE:
+   kind: call
+   all:
+     - has:
+         stopBy: neighbor
+         kind: attribute
+         regex: ^ldap3.Connection$
+     - has:
+         stopBy: neighbor
+         kind: argument_list
+         has:
+           stopBy: neighbor
+           kind: keyword_argument
+           all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^password$
+                nthChild: 1
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                pattern: $INST
+                nthChild: 2
+     - inside:
+         stopBy: end
+         follows:
+          stopBy: end
+          kind: expression_statement
+          has:
+            kind: assignment
+            all:
+              - has:
+                  kind: identifier
+                  pattern: $INST
+                  nthChild: 1
+              - has:
+                  kind: string
+                  not:
+                    has:
+                      kind: string_content
+
+  ldap3.Connection(..., password="",...):
+   kind: call
+   all:
+     - has:
+         stopBy: neighbor
+         kind: attribute
+         regex: ^ldap3.Connection$
+     - has:
+         stopBy: neighbor
+         kind: argument_list
+         has:
+           stopBy: neighbor
+           kind: keyword_argument
+           all:
+            - has:
+                stopBy: neighbor
+                kind: identifier
+                regex: ^password$
+            - has:
+                stopBy: neighbor
+                kind: string
+                not:
+                  has:
+                   stopBy: end
+                   kind: string_content
+
+rule:
+  kind: call
+  any:
+    - matches: ldap3.Connection(..., password="",...)_INSTANCE
+    - matches: ldap3.Connection(..., password="",...)
+  not:
+    all:
+      - has:
+          stopBy: end
+          kind: ERROR
+      - inside:
+          stopBy: end
+          kind: ERROR

--- a/rules/python/security/python-ldap3-hardcoded-secret-python.yml
+++ b/rules/python/security/python-ldap3-hardcoded-secret-python.yml
@@ -1,0 +1,153 @@
+id: python-ldap3-hardcoded-secret-python
+language: python
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source
+  code, such as credentials, identifiers, and other types of sensitive data,
+  can be leaked and used by internal or external malicious actors. Use
+  environment variables to securely provide credentials and other secrets or
+  retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798]: Use of Hard-coded Credentials
+  [OWASP A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+       https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+ast-grep-essentials: true
+
+utils:
+  define_string:
+    kind: string
+    all:
+      - has:
+          kind: string_start
+          nthChild: 1
+      - has:
+          kind: string_content
+          nthChild: 2
+      - has:
+          kind: string_end
+          nthChild: 3
+
+  define_password:
+    any:
+      - matches: define_string
+      - kind: identifier
+        pattern: $PWD_IDENTIFIER
+        inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: end
+              kind: assignment
+              nthChild: 1
+              all:
+                - has:
+                    nthChild: 1
+                    kind: identifier
+                    field: left
+                    pattern: $PWD_IDENTIFIER
+                - has:
+                    nthChild: 2
+                    matches: define_string
+
+rule:
+  any:
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            regex: ^Connection$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^password$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^ldap3$
+                precedes:
+                  stopBy: end
+                  kind: dotted_name
+                  regex: ^Connection$
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            pattern: $SASL_ALIAS
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^password$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^ldap3$
+                precedes:
+                  stopBy: end
+                  kind: aliased_import
+                  all:
+                    - has:
+                        kind: dotted_name
+                        nthChild: 1
+                        regex: ^Connection$
+                    - has:
+                        kind: identifier
+                        field: alias
+                        nthChild: 2
+                        pattern: $SASL_ALIAS
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: attribute
+            regex: ^ldap3.Connection$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^password$
+                  - has:
+                      nthChild: 2
+                      matches: define_password

--- a/rules/python/security/python-mariadb-empty-password-python.yml
+++ b/rules/python/security/python-mariadb-empty-password-python.yml
@@ -1,0 +1,203 @@
+id: python-mariadb-empty-password-python
+severity: warning
+language: python
+message: >-
+      The application creates a database connection with an empty password.
+      This can lead to unauthorized access by either an internal or external
+      malicious actor. To prevent this vulnerability, enforce authentication
+      when connecting to a database by using environment variables to securely
+      provide credentials or retrieving them from a secure vault or HSM
+      (Hardware Security Module).
+note: >-
+  [CWE-287] Improper Authentication.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+ast-grep-essentials: true
+
+utils:
+  define_string:
+    kind: string
+    all:
+      - has:
+          kind: string_start
+          nthChild: 1
+      - has:
+          kind: string_end
+          nthChild: 2
+      - not:
+          has:
+            kind: string_content
+
+  define_password:
+    any:
+      - matches: define_string
+      - kind: identifier
+        pattern: $PWD_IDENTIFIER
+        inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: end
+              kind: assignment
+              nthChild: 1
+              all:
+                - has:
+                    nthChild: 1
+                    kind: identifier
+                    field: left
+                    pattern: $PWD_IDENTIFIER
+                - has:
+                    nthChild: 2
+                    matches: define_string
+
+rule:
+  any:
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            regex: ^connect$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^(password|passwd)$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^mariadb$
+                precedes:
+                  stopBy: end
+                  kind: dotted_name
+                  regex: ^connect$
+
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            pattern: $SASL_ALIAS
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^(password|passwd)$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^mariadb$
+                precedes:
+                  stopBy: end
+                  kind: aliased_import
+                  all:
+                    - has:
+                        kind: dotted_name
+                        nthChild: 1
+                        regex: ^connect$
+                    - has:
+                        kind: identifier
+                        field: alias
+                        nthChild: 2
+                        pattern: $SASL_ALIAS
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: attribute
+            regex: ^mariadb.connect$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^(password|passwd)$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: attribute
+            all:
+              - has:
+                  nthChild: 1
+                  kind: identifier
+                  field: object
+                  pattern: $MARIADB_ALIAS
+              - has:
+                  nthChild: 2
+                  kind: identifier
+                  field: attribute
+                  regex: ^connect$
+            # regex: ^mariadb.connect$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^(password|passwd)$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_statement
+          has:
+            nthChild: 1
+            kind: aliased_import
+            all:
+              - has:
+                  nthChild: 1
+                  kind: dotted_name
+                  field: name
+                  regex: ^mariadb$
+              - has:
+                  nthChild: 2
+                  kind: identifier
+                  field: alias
+                  pattern: $MARIADB_ALIAS

--- a/rules/python/security/python-mariadb-hardcoded-secret-python.yml
+++ b/rules/python/security/python-mariadb-hardcoded-secret-python.yml
@@ -1,0 +1,203 @@
+id: python-mariadb-hardcoded-secret-python
+language: python
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source
+  code, such as credentials, identifiers, and other types of sensitive data,
+  can be leaked and used by internal or external malicious actors. Use
+  environment variables to securely provide credentials and other secrets or
+  retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-798]: Use of Hard-coded Credentials
+  [OWASP A07:2021]: Identification and Authentication Failures
+  [REFERENCES]
+       https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+ast-grep-essentials: true
+
+utils:
+  define_string:
+    kind: string
+    all:
+      - has:
+          kind: string_start
+          nthChild: 1
+      - has:
+          kind: string_content
+          nthChild: 2
+      - has:
+          kind: string_end
+          nthChild: 3
+
+  define_password:
+    any:
+      - matches: define_string
+      - kind: identifier
+        pattern: $PWD_IDENTIFIER
+        inside:
+          stopBy: end
+          follows:
+            stopBy: end
+            kind: expression_statement
+            has:
+              stopBy: end
+              kind: assignment
+              nthChild: 1
+              all:
+                - has:
+                    nthChild: 1
+                    kind: identifier
+                    field: left
+                    pattern: $PWD_IDENTIFIER
+                - has:
+                    nthChild: 2
+                    matches: define_string
+
+rule:
+  any:
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            regex: ^connect$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^(password|passwd)$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^mariadb$
+                precedes:
+                  stopBy: end
+                  kind: dotted_name
+                  regex: ^connect$
+
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: identifier
+            pattern: $SASL_ALIAS
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^(password|passwd)$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_from_statement
+          all:
+            - has:
+                nthChild: 1
+                kind: dotted_name
+                field: module_name
+                regex: ^mariadb$
+                precedes:
+                  stopBy: end
+                  kind: aliased_import
+                  all:
+                    - has:
+                        kind: dotted_name
+                        nthChild: 1
+                        regex: ^connect$
+                    - has:
+                        kind: identifier
+                        field: alias
+                        nthChild: 2
+                        pattern: $SASL_ALIAS
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: attribute
+            regex: ^mariadb.connect$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^(password|passwd)$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+    - kind: call
+      any:
+        - kind: call
+          has:
+            kind: attribute
+            all:
+              - has:
+                  nthChild: 1
+                  kind: identifier
+                  field: object
+                  pattern: $MARIADB_ALIAS
+              - has:
+                  nthChild: 2
+                  kind: identifier
+                  field: attribute
+                  regex: ^connect$
+            # regex: ^mariadb.connect$
+            precedes:
+              kind: argument_list
+              has:
+                stopBy: end
+                kind: keyword_argument
+                all:
+                  - has:
+                      nthChild: 1
+                      kind: identifier
+                      regex: ^(password|passwd)$
+                  - has:
+                      nthChild: 2
+                      matches: define_password
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_statement
+          has:
+            nthChild: 1
+            kind: aliased_import
+            all:
+              - has:
+                  nthChild: 1
+                  kind: dotted_name
+                  field: name
+                  regex: ^mariadb$
+              - has:
+                  nthChild: 2
+                  kind: identifier
+                  field: alias
+                  pattern: $MARIADB_ALIAS

--- a/tests/__snapshots__/python-ldap3-empty-password-python-snapshot.yml
+++ b/tests/__snapshots__/python-ldap3-empty-password-python-snapshot.yml
@@ -1,0 +1,77 @@
+id: python-ldap3-empty-password-python
+snapshots:
+  ? |
+    ldap3.Connection(password="")
+  : labels:
+    - source: ldap3.Connection(password="")
+      style: primary
+      start: 0
+      end: 29
+    - source: ldap3.Connection
+      style: secondary
+      start: 0
+      end: 16
+    - source: password
+      style: secondary
+      start: 17
+      end: 25
+    - source: '""'
+      style: secondary
+      start: 26
+      end: 28
+    - source: password=""
+      style: secondary
+      start: 17
+      end: 28
+    - source: (password="")
+      style: secondary
+      start: 16
+      end: 29
+  ? |-
+    test = ""
+    ldap3.Connection(password=test)
+  : labels:
+    - source: ldap3.Connection(password=test)
+      style: primary
+      start: 10
+      end: 41
+    - source: ldap3.Connection
+      style: secondary
+      start: 10
+      end: 26
+    - source: password
+      style: secondary
+      start: 27
+      end: 35
+    - source: test
+      style: secondary
+      start: 36
+      end: 40
+    - source: password=test
+      style: secondary
+      start: 27
+      end: 40
+    - source: (password=test)
+      style: secondary
+      start: 26
+      end: 41
+    - source: test
+      style: secondary
+      start: 0
+      end: 4
+    - source: '""'
+      style: secondary
+      start: 7
+      end: 9
+    - source: test = ""
+      style: secondary
+      start: 0
+      end: 9
+    - source: test = ""
+      style: secondary
+      start: 0
+      end: 9
+    - source: test = ""
+      style: secondary
+      start: 0
+      end: 9

--- a/tests/__snapshots__/python-ldap3-hardcoded-secret-python-snapshot.yml
+++ b/tests/__snapshots__/python-ldap3-hardcoded-secret-python-snapshot.yml
@@ -1,0 +1,101 @@
+id: python-ldap3-hardcoded-secret-python
+snapshots:
+  ? |
+    ldap3.Connection(password="test")
+  : labels:
+    - source: ldap3.Connection(password="test")
+      style: primary
+      start: 0
+      end: 33
+    - source: password
+      style: secondary
+      start: 17
+      end: 25
+    - source: '"'
+      style: secondary
+      start: 26
+      end: 27
+    - source: test
+      style: secondary
+      start: 27
+      end: 31
+    - source: '"'
+      style: secondary
+      start: 31
+      end: 32
+    - source: '"test"'
+      style: secondary
+      start: 26
+      end: 32
+    - source: password="test"
+      style: secondary
+      start: 17
+      end: 32
+    - source: (password="test")
+      style: secondary
+      start: 16
+      end: 33
+    - source: ldap3.Connection
+      style: secondary
+      start: 0
+      end: 16
+  ? |-
+    test = "password"
+    ldap3.Connection(password=test)
+  : labels:
+    - source: ldap3.Connection(password=test)
+      style: primary
+      start: 18
+      end: 49
+    - source: password
+      style: secondary
+      start: 35
+      end: 43
+    - source: test
+      style: secondary
+      start: 0
+      end: 4
+    - source: '"'
+      style: secondary
+      start: 7
+      end: 8
+    - source: password
+      style: secondary
+      start: 8
+      end: 16
+    - source: '"'
+      style: secondary
+      start: 16
+      end: 17
+    - source: '"password"'
+      style: secondary
+      start: 7
+      end: 17
+    - source: test = "password"
+      style: secondary
+      start: 0
+      end: 17
+    - source: test = "password"
+      style: secondary
+      start: 0
+      end: 17
+    - source: test = "password"
+      style: secondary
+      start: 0
+      end: 17
+    - source: test
+      style: secondary
+      start: 44
+      end: 48
+    - source: password=test
+      style: secondary
+      start: 35
+      end: 48
+    - source: (password=test)
+      style: secondary
+      start: 34
+      end: 49
+    - source: ldap3.Connection
+      style: secondary
+      start: 18
+      end: 34

--- a/tests/__snapshots__/python-mariadb-empty-password-python-snapshot.yml
+++ b/tests/__snapshots__/python-mariadb-empty-password-python-snapshot.yml
@@ -1,0 +1,157 @@
+id: python-mariadb-empty-password-python
+snapshots:
+  ? |
+    PASSWORD1 = ""
+    conn = mariadb.connect(password=PASSWORD1)
+  : labels:
+    - source: mariadb.connect(password=PASSWORD1)
+      style: primary
+      start: 22
+      end: 57
+    - source: password
+      style: secondary
+      start: 38
+      end: 46
+    - source: PASSWORD1
+      style: secondary
+      start: 0
+      end: 9
+    - source: '"'
+      style: secondary
+      start: 12
+      end: 13
+    - source: '"'
+      style: secondary
+      start: 13
+      end: 14
+    - source: '""'
+      style: secondary
+      start: 12
+      end: 14
+    - source: PASSWORD1 = ""
+      style: secondary
+      start: 0
+      end: 14
+    - source: PASSWORD1 = ""
+      style: secondary
+      start: 0
+      end: 14
+    - source: PASSWORD1 = ""
+      style: secondary
+      start: 0
+      end: 14
+    - source: PASSWORD1
+      style: secondary
+      start: 47
+      end: 56
+    - source: password=PASSWORD1
+      style: secondary
+      start: 38
+      end: 56
+    - source: (password=PASSWORD1)
+      style: secondary
+      start: 37
+      end: 57
+    - source: mariadb.connect
+      style: secondary
+      start: 22
+      end: 37
+  ? |
+    conn = mariadb.connect(password="")
+  : labels:
+    - source: mariadb.connect(password="")
+      style: primary
+      start: 7
+      end: 35
+    - source: password
+      style: secondary
+      start: 23
+      end: 31
+    - source: '"'
+      style: secondary
+      start: 32
+      end: 33
+    - source: '"'
+      style: secondary
+      start: 33
+      end: 34
+    - source: '""'
+      style: secondary
+      start: 32
+      end: 34
+    - source: password=""
+      style: secondary
+      start: 23
+      end: 34
+    - source: (password="")
+      style: secondary
+      start: 22
+      end: 35
+    - source: mariadb.connect
+      style: secondary
+      start: 7
+      end: 22
+  ? |
+    import mariadb as mrdbl123
+    mrdbl123.connect(host="this.is.my.host",user="root",passwd="",database="aaa")
+  : labels:
+    - source: mrdbl123.connect(host="this.is.my.host",user="root",passwd="",database="aaa")
+      style: primary
+      start: 27
+      end: 104
+    - source: mrdbl123
+      style: secondary
+      start: 27
+      end: 35
+    - source: connect
+      style: secondary
+      start: 36
+      end: 43
+    - source: passwd
+      style: secondary
+      start: 79
+      end: 85
+    - source: '"'
+      style: secondary
+      start: 86
+      end: 87
+    - source: '"'
+      style: secondary
+      start: 87
+      end: 88
+    - source: '""'
+      style: secondary
+      start: 86
+      end: 88
+    - source: passwd=""
+      style: secondary
+      start: 79
+      end: 88
+    - source: (host="this.is.my.host",user="root",passwd="",database="aaa")
+      style: secondary
+      start: 43
+      end: 104
+    - source: mrdbl123.connect
+      style: secondary
+      start: 27
+      end: 43
+    - source: mariadb
+      style: secondary
+      start: 7
+      end: 14
+    - source: mrdbl123
+      style: secondary
+      start: 18
+      end: 26
+    - source: mariadb as mrdbl123
+      style: secondary
+      start: 7
+      end: 26
+    - source: import mariadb as mrdbl123
+      style: secondary
+      start: 0
+      end: 26
+    - source: import mariadb as mrdbl123
+      style: secondary
+      start: 0
+      end: 26

--- a/tests/__snapshots__/python-mariadb-hardcoded-secret-python-snapshot.yml
+++ b/tests/__snapshots__/python-mariadb-hardcoded-secret-python-snapshot.yml
@@ -1,0 +1,169 @@
+id: python-mariadb-hardcoded-secret-python
+snapshots:
+  ? |
+    PASSWORD1 = "test"
+    conn = mariadb.connect(password=PASSWORD1)
+  : labels:
+    - source: mariadb.connect(password=PASSWORD1)
+      style: primary
+      start: 26
+      end: 61
+    - source: password
+      style: secondary
+      start: 42
+      end: 50
+    - source: PASSWORD1
+      style: secondary
+      start: 0
+      end: 9
+    - source: '"'
+      style: secondary
+      start: 12
+      end: 13
+    - source: test
+      style: secondary
+      start: 13
+      end: 17
+    - source: '"'
+      style: secondary
+      start: 17
+      end: 18
+    - source: '"test"'
+      style: secondary
+      start: 12
+      end: 18
+    - source: PASSWORD1 = "test"
+      style: secondary
+      start: 0
+      end: 18
+    - source: PASSWORD1 = "test"
+      style: secondary
+      start: 0
+      end: 18
+    - source: PASSWORD1 = "test"
+      style: secondary
+      start: 0
+      end: 18
+    - source: PASSWORD1
+      style: secondary
+      start: 51
+      end: 60
+    - source: password=PASSWORD1
+      style: secondary
+      start: 42
+      end: 60
+    - source: (password=PASSWORD1)
+      style: secondary
+      start: 41
+      end: 61
+    - source: mariadb.connect
+      style: secondary
+      start: 26
+      end: 41
+  ? |
+    conn = mariadb.connect(password="test")
+  : labels:
+    - source: mariadb.connect(password="test")
+      style: primary
+      start: 7
+      end: 39
+    - source: password
+      style: secondary
+      start: 23
+      end: 31
+    - source: '"'
+      style: secondary
+      start: 32
+      end: 33
+    - source: test
+      style: secondary
+      start: 33
+      end: 37
+    - source: '"'
+      style: secondary
+      start: 37
+      end: 38
+    - source: '"test"'
+      style: secondary
+      start: 32
+      end: 38
+    - source: password="test"
+      style: secondary
+      start: 23
+      end: 38
+    - source: (password="test")
+      style: secondary
+      start: 22
+      end: 39
+    - source: mariadb.connect
+      style: secondary
+      start: 7
+      end: 22
+  ? |
+    import mariadb as mrdbl123
+    mrdbl123.connect(host="this.is.my.host",user="root",passwd="test",database="aaa")
+  : labels:
+    - source: mrdbl123.connect(host="this.is.my.host",user="root",passwd="test",database="aaa")
+      style: primary
+      start: 27
+      end: 108
+    - source: mrdbl123
+      style: secondary
+      start: 27
+      end: 35
+    - source: connect
+      style: secondary
+      start: 36
+      end: 43
+    - source: passwd
+      style: secondary
+      start: 79
+      end: 85
+    - source: '"'
+      style: secondary
+      start: 86
+      end: 87
+    - source: test
+      style: secondary
+      start: 87
+      end: 91
+    - source: '"'
+      style: secondary
+      start: 91
+      end: 92
+    - source: '"test"'
+      style: secondary
+      start: 86
+      end: 92
+    - source: passwd="test"
+      style: secondary
+      start: 79
+      end: 92
+    - source: (host="this.is.my.host",user="root",passwd="test",database="aaa")
+      style: secondary
+      start: 43
+      end: 108
+    - source: mrdbl123.connect
+      style: secondary
+      start: 27
+      end: 43
+    - source: mariadb
+      style: secondary
+      start: 7
+      end: 14
+    - source: mrdbl123
+      style: secondary
+      start: 18
+      end: 26
+    - source: mariadb as mrdbl123
+      style: secondary
+      start: 7
+      end: 26
+    - source: import mariadb as mrdbl123
+      style: secondary
+      start: 0
+      end: 26
+    - source: import mariadb as mrdbl123
+      style: secondary
+      start: 0
+      end: 26

--- a/tests/python/python-ldap3-empty-password-python-test.yml
+++ b/tests/python/python-ldap3-empty-password-python-test.yml
@@ -1,0 +1,10 @@
+id: python-ldap3-empty-password-python
+valid:
+  - |
+    ldap3.Connection(password=test)
+invalid:
+  - |
+    ldap3.Connection(password="")
+  - |
+    test = ""
+    ldap3.Connection(password=test)

--- a/tests/python/python-ldap3-hardcoded-secret-python-test.yml
+++ b/tests/python/python-ldap3-hardcoded-secret-python-test.yml
@@ -1,0 +1,10 @@
+id: python-ldap3-hardcoded-secret-python
+valid:
+  - |
+    ldap3.Connection(password=test)
+invalid:
+  - |
+    ldap3.Connection(password="test")
+  - |
+    test = "password"
+    ldap3.Connection(password=test)

--- a/tests/python/python-mariadb-empty-password-python-test.yml
+++ b/tests/python/python-mariadb-empty-password-python-test.yml
@@ -1,0 +1,13 @@
+id: python-mariadb-empty-password-python
+valid:
+  - |
+    mysql_db1 = MySQLDatabe('my_app', user='app', password=os.env['pass'], host='10.1.0.8', port=3306)
+invalid:
+  - |
+    PASSWORD1 = ""
+    conn = mariadb.connect(password=PASSWORD1)
+  - |
+    conn = mariadb.connect(password="")
+  - |
+    import mariadb as mrdbl123
+    mrdbl123.connect(host="this.is.my.host",user="root",passwd="",database="aaa")

--- a/tests/python/python-mariadb-hardcoded-secret-python-test.yml
+++ b/tests/python/python-mariadb-hardcoded-secret-python-test.yml
@@ -1,0 +1,13 @@
+id: python-mariadb-hardcoded-secret-python
+valid:
+  - |
+    mysql_db1 = MySQLDatabe('my_app', user='app', password=os.env['pass'], host='10.1.0.8', port=3306)
+invalid:
+  - |
+    PASSWORD1 = "test"
+    conn = mariadb.connect(password=PASSWORD1)
+  - |
+    conn = mariadb.connect(password="test")
+  - |
+    import mariadb as mrdbl123
+    mrdbl123.connect(host="this.is.my.host",user="root",passwd="test",database="aaa")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced security enhancements to identify insecure password configurations in Python applications using LDAP and MariaDB, helping ensure proper credential management.
  
- **Tests**
  - Added comprehensive test scenarios and snapshot validations to confirm the effectiveness of these security rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->